### PR TITLE
New template for AAD app registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # azure-devops-templates
 Contains library of Azure DevOps yaml templates
+
+## Build status
+[![Build Status](https://hmctsreform.visualstudio.com/VirtualHearings/_apis/build/status/Tools/hmcts.azure-devops-templates?branchName=master)](https://hmctsreform.visualstudio.com/VirtualHearings/_build/latest?definitionId=75?branchName=master)
+
+
 ## Usage
+### Building Angular & .Net Core solution 
 Copy Example\azure-pipelines.yml in the root of the github repository together with applications source code
 
 Make sure to select the appropriate solution type **angularDotNetCore** or **dotNetCore** in azure-pipelines.yml file.
+
+### AAD Application registration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,11 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 steps:
+- task: GitVersion@3
+  displayName: GitVersion
+  inputs:
+    updateAssemblyInfo: false
+
 - task: NodeTool@0
   inputs:
     versionSpec: '8.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,9 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 steps:
+
+- bash: sudo apt-get install libcurl3
+
 - task: GitVersion@3
   displayName: GitVersion
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,14 @@ pool:
 
 steps:
 
-- bash: sudo apt-get install libcurl3
-
+- bash: |
+    shopt -s nullglob
+    function join_by { local IFS="$1"; shift; echo "$*"; }
+    lib_path=$(join_by ';' $(Agent.WorkFolder)/_tasks/GitVersion*/4.0.*/lib/linux/x86_64)
+    echo LD_LIBRARY_PATH: $lib_path
+    echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$lib_path"
+  displayName: Update LD_LIBRARY_PATH for GitVersion
+  
 - task: GitVersion@3
   displayName: GitVersion
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,8 @@ steps:
     echo LD_LIBRARY_PATH: $lib_path
     echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$lib_path"
   displayName: Update LD_LIBRARY_PATH for GitVersion
-  
-- task: GitVersion@3
+
+- task: GitVersion@4
   displayName: GitVersion
   inputs:
     updateAssemblyInfo: false

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -1,14 +1,14 @@
 
 parameters:
   serviceName: 'vh-app-api' # name of the app to be registered
-  keyVaultName: 'vhcoreinfraht$(environmentName)' # key vault name to for storing AAD app's details - appId, ClientSecret, etc.
-  resourceGroupName: $(serviceName)-$(environmentName) # resource group name for where the website is located
-  AppServicePlanName: vh-core-infra-$(environmentName) # App Service Plan name
+  keyVaultName: '' # key vault name to for storing AAD app's details - appId, ClientSecret, etc.
+  resourceGroupName: '' # resource group name for where the website is located
+  AppServicePlanName: '' # App Service Plan name
   WebSiteName: $(serviceName)-$(environmentName)  # Web Site name
   CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
   aadAppReplyUrls: '' #CSV list of replay urls
 
-#${{ parameters.aadAppReplyUrls }}
+#${{ parameters.AppServicePlanName }}
 
 
 jobs:
@@ -23,8 +23,8 @@ jobs:
 
   - powershell: |
      git clone https://github.com/hmcts/vh-ps-modules.git
-     cd .\vh-ps-modules\
-     git checkout updated-dns-module
+    #  cd .\vh-ps-modules\
+    #  git checkout updated-dns-module
     displayName: 'Get PowerShell module source'
 
   - powershell: | 
@@ -75,9 +75,9 @@ jobs:
     inputs:
       azureSubscription: 'Reform-CFT-VH-Dev'
       action: 'Create Or Update Resource Group'
-      resourceGroupName: '$(resourceGroupName)'
+      resourceGroupName: '${{ parameters.resourceGroupName }}'
       location: 'UK West'
       csmFile: 'infrastructure/azuredeploy.json'
       csmParametersFile: 'infrastructure/azuredeploy.parameters.json'
-      overrideParameters: -appServicePlanName $(AppServicePlanName) -AzureWebsite $(WebSiteName) -customHostname $(CustomHostname) -certificateThumbprint $(WildcardCertificateThumbprint)
+      overrideParameters: -appServicePlanName ${{ parameters.AppServicePlanName }} -AzureWebsite $(WebSiteName) -customHostname $(CustomHostname) -certificateThumbprint $(WildcardCertificateThumbprint)
       deploymentMode: Incremental

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -6,78 +6,73 @@ parameters:
   AppServicePlanName: vh-core-infra-$(environmentName) # App Service Plan name
   WebSiteName: $(serviceName)-$(environmentName)  # Web Site name
   CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
-  aadAppReplyUrls: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName), https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/login, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/dashboard, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/logout #CSV list of replay urls
+  aadAppReplyUrls: '' #CSV list of replay urls
 
 #${{ parameters.aadAppReplyUrls }}
 
 
-jobs:
-- job: Register_AAD_App
+# Reference templae for setting up build tools
+steps:
+- checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+  clean: true  # whether to fetch clean each time
+
+- powershell: |
+    git clone https://github.com/hmcts/vh-ps-modules.git
+    cd .\vh-ps-modules\
+    git checkout updated-dns-module
+  displayName: 'Get PowerShell module source'
+
+- powershell: | 
+    #Get-ChildItem -Recurse
+    Install-Module AzureAD
+    Install-Module AzureRM.KeyVault
+    Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/AzureADApplicationRegistration -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
+    Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/SetDNSRecord -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
+  displayName: 'Import PowerShell Modules'
+
+- powershell: | 
+    Invoke-AzureADApplicationRegistration `
+    -AzureTenantId '$(vh_teantid)' `
+    -AzureAdAppId '$(vh_vsts_automation_dev_AppId)' `
+    -AzureAdAppCertificateThumbprint '$(vh_vsts_automation_dev_CertThumbprit)' `
+    -AzureSubscriptionId '$(vh_azure_subscription_id_dev)' `
+    -AzureADApplicationName '${{ parameters.serviceName }}-$(environmentName)' `
+    -AzureKeyVaultName '${{ parameters.keyVaultName }}' `
+    -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
+    -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
+    -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
+    -verbose
   displayName: 'Register AAD App'
-  pool: Azure-VSTS-VS2017
 
-  # Reference templae for setting up build tools
-  steps:
-  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-    clean: true  # whether to fetch clean each time
+- powershell: | 
+    Set-AzureADApplicationReplyUrls `
+    -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
+    -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
+    -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
+    -AADAppName "${{ parameters.serviceName }}-$(environmentName)" `
+    -AADAppReplyUrls "${{ parameters.aadAppReplyUrls }}"
+  displayName: 'Set AAD App Replay URLs'
 
-  - powershell: |
-     git clone https://github.com/hmcts/vh-ps-modules.git
-     cd .\vh-ps-modules\
-     git checkout updated-dns-module
-    displayName: 'Get PowerShell module source'
+- task: AzurePowerShell@3
+  displayName: 'Set DNS records for web app'
+  inputs:
+    azureSubscription: 'DCD-CFT-VH-Pilot'
+    azurePowerShellVersion: LatestVersion
+    ScriptType: InlineScript
+    Inline: |
+      Set-AzureRmDnsRecord -WebSiteName "${{ parameters.serviceName }}-$(environmentName)" `
+      -AzureAppServiceWebSiteDomainName "$(AzureAppServiceWebSiteDomainName)" `
+      -AzureResourceGroupName "$(AzureResourceGroupName)" `
+      -AzureDNSZoneName "$(AzureDNSZoneName)"
 
-  - powershell: | 
-      #Get-ChildItem -Recurse
-      Install-Module AzureAD
-      Install-Module AzureRM.KeyVault
-      Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/AzureADApplicationRegistration -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
-      Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/SetDNSRecord -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
-    displayName: 'Import PowerShell Modules'
-
-  - powershell: | 
-     Invoke-AzureADApplicationRegistration `
-     -AzureTenantId '$(vh_teantid)' `
-     -AzureAdAppId '$(vh_vsts_automation_dev_AppId)' `
-     -AzureAdAppCertificateThumbprint '$(vh_vsts_automation_dev_CertThumbprit)' `
-     -AzureSubscriptionId '$(vh_azure_subscription_id_dev)' `
-     -AzureADApplicationName '${{ parameters.serviceName }}-$(environmentName)' `
-     -AzureKeyVaultName '${{ parameters.keyVaultName }}' `
-     -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
-     -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
-     -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
-     -verbose
-    displayName: 'Register AAD App'
-
-  - powershell: | 
-      Set-AzureADApplicationReplyUrls `
-      -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
-      -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
-      -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
-      -AADAppName "${{ parameters.serviceName }}-$(environmentName)" `
-      -AADAppReplyUrls "${{ parameters.aadAppReplyUrls }}"
-    displayName: 'Set AAD App Replay URLs'
-
-  - task: AzurePowerShell@3
-    displayName: 'Set DNS records for web app'
-    inputs:
-      azureSubscription: 'DCD-CFT-VH-Pilot'
-      azurePowerShellVersion: LatestVersion
-      ScriptType: InlineScript
-      Inline: |
-        Set-AzureRmDnsRecord -WebSiteName "${{ parameters.serviceName }}-$(environmentName)" `
-        -AzureAppServiceWebSiteDomainName "$(AzureAppServiceWebSiteDomainName)" `
-        -AzureResourceGroupName "$(AzureResourceGroupName)" `
-        -AzureDNSZoneName "$(AzureDNSZoneName)"
-
-  - task: AzureResourceGroupDeployment@2
-    displayName: 'Provision Web App'
-    inputs:
-      azureSubscription: 'Reform-CFT-VH-Dev'
-      action: 'Create Or Update Resource Group'
-      resourceGroupName: '$(resourceGroupName)'
-      location: 'UK West'
-      csmFile: 'infrastructure/azuredeploy.json'
-      csmParametersFile: 'infrastructure/azuredeploy.parameters.json'
-      overrideParameters: -appServicePlanName $(AppServicePlanName) -AzureWebsite $(WebSiteName) -customHostname $(CustomHostname) -certificateThumbprint $(WildcardCertificateThumbprint)
-      deploymentMode: Incremental
+- task: AzureResourceGroupDeployment@2
+  displayName: 'Provision Web App'
+  inputs:
+    azureSubscription: 'Reform-CFT-VH-Dev'
+    action: 'Create Or Update Resource Group'
+    resourceGroupName: '$(resourceGroupName)'
+    location: 'UK West'
+    csmFile: 'infrastructure/azuredeploy.json'
+    csmParametersFile: 'infrastructure/azuredeploy.parameters.json'
+    overrideParameters: -appServicePlanName $(AppServicePlanName) -AzureWebsite $(WebSiteName) -customHostname $(CustomHostname) -certificateThumbprint $(WildcardCertificateThumbprint)
+    deploymentMode: Incremental

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -8,7 +8,7 @@ parameters:
   CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
   AADAppReplyUrls: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName), https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/login, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/dashboard, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/logout #CSV list of replay urls
 
-#'${{ parameters.serviceName }}'
+#${{ parameters.serviceName }}
 
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
      -AzureAdAppId '$(vh_vsts_automation_dev_AppId)' `
      -AzureAdAppCertificateThumbprint '$(vh_vsts_automation_dev_CertThumbprit)' `
      -AzureSubscriptionId '$(vh_azure_subscription_id_dev)' `
-     -AzureADApplicationName ''${{ parameters.serviceName }}'-$(environmentName)' `
+     -AzureADApplicationName '${{ parameters.serviceName }}-$(environmentName)' `
      -AzureKeyVaultName '${{ parameters.keyVaultName }}' `
      -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
      -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
@@ -54,7 +54,7 @@ jobs:
       -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
       -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
       -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
-      -AADAppName "'${{ parameters.serviceName }}'-$(environmentName)" `
+      -AADAppName "${{ parameters.serviceName }}-$(environmentName)" `
       -AADAppReplyUrls "$(AADAppReplyUrls)"
     displayName: 'Set AAD App Replay URLs'
 
@@ -65,7 +65,7 @@ jobs:
       azurePowerShellVersion: LatestVersion
       ScriptType: InlineScript
       Inline: |
-        Set-AzureRmDnsRecord -WebSiteName "'${{ parameters.serviceName }}'-$(environmentName)" `
+        Set-AzureRmDnsRecord -WebSiteName "${{ parameters.serviceName }}-$(environmentName)" `
         -AzureAppServiceWebSiteDomainName "$(AzureAppServiceWebSiteDomainName)" `
         -AzureResourceGroupName "$(AzureResourceGroupName)" `
         -AzureDNSZoneName "$(AzureDNSZoneName)"

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -1,5 +1,9 @@
 
 parameters:
+  # build agent pool can be overwritten on build template level 
+  pool: 'Azure-VSTS-VS2017'
+  azureSubscription: 'Reform-CFT-VH-Dev'
+
   appName: 'vh-app-api' # name of the app to be registered
   keyVaultName: 'vhcoreinfraht$(environmentName)' # key vault name to for storing AAD app's details - appId, ClientSecret, etc.
   resourceGroupName: '$(appName)-$(environmentName)' # resource group name for where the website is located
@@ -7,8 +11,6 @@ parameters:
   WebSiteName: $(appName)-$(environmentName)  # Web Site name
   CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
   aadAppReplyUrls: '' #CSV list of replay urls
-
-#${{ parameters.CustomHostname }}
 
 
 jobs:

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -10,13 +10,9 @@ parameters:
 
 #'${{ parameters.serviceName }}'
 
-trigger:
-- master
-pr:
-- master
 
 jobs:
-- job: 
+- job: Register_AAD_App
   displayName: 'Register AAD App'
   pool: Azure-VSTS-VS2017
 

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -11,68 +11,73 @@ parameters:
 #${{ parameters.aadAppReplyUrls }}
 
 
-# Reference templae for setting up build tools
-steps:
-- checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-  clean: true  # whether to fetch clean each time
-
-- powershell: |
-    git clone https://github.com/hmcts/vh-ps-modules.git
-    cd .\vh-ps-modules\
-    git checkout updated-dns-module
-  displayName: 'Get PowerShell module source'
-
-- powershell: | 
-    #Get-ChildItem -Recurse
-    Install-Module AzureAD
-    Install-Module AzureRM.KeyVault
-    Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/AzureADApplicationRegistration -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
-    Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/SetDNSRecord -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
-  displayName: 'Import PowerShell Modules'
-
-- powershell: | 
-    Invoke-AzureADApplicationRegistration `
-    -AzureTenantId '$(vh_teantid)' `
-    -AzureAdAppId '$(vh_vsts_automation_dev_AppId)' `
-    -AzureAdAppCertificateThumbprint '$(vh_vsts_automation_dev_CertThumbprit)' `
-    -AzureSubscriptionId '$(vh_azure_subscription_id_dev)' `
-    -AzureADApplicationName '${{ parameters.serviceName }}-$(environmentName)' `
-    -AzureKeyVaultName '${{ parameters.keyVaultName }}' `
-    -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
-    -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
-    -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
-    -verbose
+jobs:
+- job: Register_AAD_App
   displayName: 'Register AAD App'
+  pool: Azure-VSTS-VS2017
 
-- powershell: | 
-    Set-AzureADApplicationReplyUrls `
-    -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
-    -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
-    -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
-    -AADAppName "${{ parameters.serviceName }}-$(environmentName)" `
-    -AADAppReplyUrls "${{ parameters.aadAppReplyUrls }}"
-  displayName: 'Set AAD App Replay URLs'
+  # Reference templae for setting up build tools
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # whether to fetch clean each time
 
-- task: AzurePowerShell@3
-  displayName: 'Set DNS records for web app'
-  inputs:
-    azureSubscription: 'DCD-CFT-VH-Pilot'
-    azurePowerShellVersion: LatestVersion
-    ScriptType: InlineScript
-    Inline: |
-      Set-AzureRmDnsRecord -WebSiteName "${{ parameters.serviceName }}-$(environmentName)" `
-      -AzureAppServiceWebSiteDomainName "$(AzureAppServiceWebSiteDomainName)" `
-      -AzureResourceGroupName "$(AzureResourceGroupName)" `
-      -AzureDNSZoneName "$(AzureDNSZoneName)"
+  - powershell: |
+     git clone https://github.com/hmcts/vh-ps-modules.git
+     cd .\vh-ps-modules\
+     git checkout updated-dns-module
+    displayName: 'Get PowerShell module source'
 
-- task: AzureResourceGroupDeployment@2
-  displayName: 'Provision Web App'
-  inputs:
-    azureSubscription: 'Reform-CFT-VH-Dev'
-    action: 'Create Or Update Resource Group'
-    resourceGroupName: '$(resourceGroupName)'
-    location: 'UK West'
-    csmFile: 'infrastructure/azuredeploy.json'
-    csmParametersFile: 'infrastructure/azuredeploy.parameters.json'
-    overrideParameters: -appServicePlanName $(AppServicePlanName) -AzureWebsite $(WebSiteName) -customHostname $(CustomHostname) -certificateThumbprint $(WildcardCertificateThumbprint)
-    deploymentMode: Incremental
+  - powershell: | 
+      #Get-ChildItem -Recurse
+      Install-Module AzureAD
+      Install-Module AzureRM.KeyVault
+      Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/AzureADApplicationRegistration -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
+      Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/SetDNSRecord -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
+    displayName: 'Import PowerShell Modules'
+
+  - powershell: | 
+     Invoke-AzureADApplicationRegistration `
+     -AzureTenantId '$(vh_teantid)' `
+     -AzureAdAppId '$(vh_vsts_automation_dev_AppId)' `
+     -AzureAdAppCertificateThumbprint '$(vh_vsts_automation_dev_CertThumbprit)' `
+     -AzureSubscriptionId '$(vh_azure_subscription_id_dev)' `
+     -AzureADApplicationName '${{ parameters.serviceName }}-$(environmentName)' `
+     -AzureKeyVaultName '${{ parameters.keyVaultName }}' `
+     -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
+     -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
+     -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
+     -verbose
+    displayName: 'Register AAD App'
+
+  - powershell: | 
+      Set-AzureADApplicationReplyUrls `
+      -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
+      -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
+      -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
+      -AADAppName "${{ parameters.serviceName }}-$(environmentName)" `
+      -AADAppReplyUrls "${{ parameters.aadAppReplyUrls }}"
+    displayName: 'Set AAD App Replay URLs'
+
+  - task: AzurePowerShell@3
+    displayName: 'Set DNS records for web app'
+    inputs:
+      azureSubscription: 'DCD-CFT-VH-Pilot'
+      azurePowerShellVersion: LatestVersion
+      ScriptType: InlineScript
+      Inline: |
+        Set-AzureRmDnsRecord -WebSiteName "${{ parameters.serviceName }}-$(environmentName)" `
+        -AzureAppServiceWebSiteDomainName "$(AzureAppServiceWebSiteDomainName)" `
+        -AzureResourceGroupName "$(AzureResourceGroupName)" `
+        -AzureDNSZoneName "$(AzureDNSZoneName)"
+
+  - task: AzureResourceGroupDeployment@2
+    displayName: 'Provision Web App'
+    inputs:
+      azureSubscription: 'Reform-CFT-VH-Dev'
+      action: 'Create Or Update Resource Group'
+      resourceGroupName: '$(resourceGroupName)'
+      location: 'UK West'
+      csmFile: 'infrastructure/azuredeploy.json'
+      csmParametersFile: 'infrastructure/azuredeploy.parameters.json'
+      overrideParameters: -appServicePlanName $(AppServicePlanName) -AzureWebsite $(WebSiteName) -customHostname $(CustomHostname) -certificateThumbprint $(WildcardCertificateThumbprint)
+      deploymentMode: Incremental

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -6,9 +6,9 @@ parameters:
   AppServicePlanName: vh-core-infra-$(environmentName) # App Service Plan name
   WebSiteName: $(serviceName)-$(environmentName)  # Web Site name
   CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
-  AADAppReplyUrls: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName), https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/login, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/dashboard, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/logout #CSV list of replay urls
+  aadAppReplyUrls: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName), https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/login, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/dashboard, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/logout #CSV list of replay urls
 
-#${{ parameters.serviceName }}
+#${{ parameters.aadAppReplyUrls }}
 
 
 jobs:
@@ -55,7 +55,7 @@ jobs:
       -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
       -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
       -AADAppName "${{ parameters.serviceName }}-$(environmentName)" `
-      -AADAppReplyUrls "$(AADAppReplyUrls)"
+      -AADAppReplyUrls "${{ parameters.aadAppReplyUrls }}"
     displayName: 'Set AAD App Replay URLs'
 
   - task: AzurePowerShell@3

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -1,9 +1,9 @@
 
 parameters:
   serviceName: 'vh-app-api' # name of the app to be registered
-  keyVaultName: '' # key vault name to for storing AAD app's details - appId, ClientSecret, etc.
-  resourceGroupName: '' # resource group name for where the website is located
-  AppServicePlanName: '' # App Service Plan name
+  keyVaultName: 'vhcoreinfraht$(environmentName)' # key vault name to for storing AAD app's details - appId, ClientSecret, etc.
+  resourceGroupName: '$(serviceName)-$(environmentName)' # resource group name for where the website is located
+  AppServicePlanName: 'vh-core-infra-$(environmentName)' # App Service Plan name
   WebSiteName: $(serviceName)-$(environmentName)  # Web Site name
   CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
   aadAppReplyUrls: '' #CSV list of replay urls

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -1,10 +1,10 @@
 
 parameters:
-  serviceName: 'vh-app-api' # name of the app to be registered
+  appName: 'vh-app-api' # name of the app to be registered
   keyVaultName: 'vhcoreinfraht$(environmentName)' # key vault name to for storing AAD app's details - appId, ClientSecret, etc.
-  resourceGroupName: '$(serviceName)-$(environmentName)' # resource group name for where the website is located
+  resourceGroupName: '$(appName)-$(environmentName)' # resource group name for where the website is located
   AppServicePlanName: 'vh-core-infra-$(environmentName)' # App Service Plan name
-  WebSiteName: $(serviceName)-$(environmentName)  # Web Site name
+  WebSiteName: $(appName)-$(environmentName)  # Web Site name
   CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
   aadAppReplyUrls: '' #CSV list of replay urls
 
@@ -41,7 +41,7 @@ jobs:
      -AzureAdAppId '$(vh_vsts_automation_dev_AppId)' `
      -AzureAdAppCertificateThumbprint '$(vh_vsts_automation_dev_CertThumbprit)' `
      -AzureSubscriptionId '$(vh_azure_subscription_id_dev)' `
-     -AzureADApplicationName '${{ parameters.serviceName }}-$(environmentName)' `
+     -AzureADApplicationName '${{ parameters.appName }}-$(environmentName)' `
      -AzureKeyVaultName '${{ parameters.keyVaultName }}' `
      -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
      -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
@@ -54,7 +54,7 @@ jobs:
       -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
       -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
       -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
-      -AADAppName "${{ parameters.serviceName }}-$(environmentName)" `
+      -AADAppName "${{ parameters.appName }}-$(environmentName)" `
       -AADAppReplyUrls "${{ parameters.aadAppReplyUrls }}"
     displayName: 'Set AAD App Replay URLs'
 
@@ -65,7 +65,7 @@ jobs:
       azurePowerShellVersion: LatestVersion
       ScriptType: InlineScript
       Inline: |
-        Set-AzureRmDnsRecord -WebSiteName "${{ parameters.serviceName }}-$(environmentName)" `
+        Set-AzureRmDnsRecord -WebSiteName "${{ parameters.appName }}-$(environmentName)" `
         -AzureAppServiceWebSiteDomainName "$(AzureAppServiceWebSiteDomainName)" `
         -AzureResourceGroupName "$(AzureResourceGroupName)" `
         -AzureDNSZoneName "$(AzureDNSZoneName)"

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -1,0 +1,87 @@
+
+parameters:
+  serviceName: 'vh-app-api' # name of the app to be registered
+  keyVaultName: 'vhcoreinfraht$(environmentName)' # key vault name to for storing AAD app's details - appId, ClientSecret, etc.
+  resourceGroupName: $(serviceName)-$(environmentName) # resource group name for where the website is located
+  AppServicePlanName: vh-core-infra-$(environmentName) # App Service Plan name
+  WebSiteName: $(serviceName)-$(environmentName)  # Web Site name
+  CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
+  AADAppReplyUrls: https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName), https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/login, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/dashboard, https://$(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName)/logout #CSV list of replay urls
+
+#'${{ parameters.serviceName }}'
+
+trigger:
+- master
+pr:
+- master
+
+jobs:
+- job: 
+  displayName: 'Register AAD App'
+  pool: Azure-VSTS-VS2017
+
+  # Reference templae for setting up build tools
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # whether to fetch clean each time
+
+  - powershell: |
+     git clone https://github.com/hmcts/vh-ps-modules.git
+     cd .\vh-ps-modules\
+     git checkout updated-dns-module
+    displayName: 'Get PowerShell module source'
+
+  - powershell: | 
+      #Get-ChildItem -Recurse
+      Install-Module AzureAD
+      Install-Module AzureRM.KeyVault
+      Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/AzureADApplicationRegistration -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
+      Copy-Item -Path $(System.DefaultWorkingDirectory)/*vh-ps-modules/SetDNSRecord -Destination "C:\Program Files\WindowsPowerShell\Modules" -Recurse -Force
+    displayName: 'Import PowerShell Modules'
+
+  - powershell: | 
+     Invoke-AzureADApplicationRegistration `
+     -AzureTenantId '$(vh_teantid)' `
+     -AzureAdAppId '$(vh_vsts_automation_dev_AppId)' `
+     -AzureAdAppCertificateThumbprint '$(vh_vsts_automation_dev_CertThumbprit)' `
+     -AzureSubscriptionId '$(vh_azure_subscription_id_dev)' `
+     -AzureADApplicationName ''${{ parameters.serviceName }}'-$(environmentName)' `
+     -AzureKeyVaultName '${{ parameters.keyVaultName }}' `
+     -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
+     -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
+     -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
+     -verbose
+    displayName: 'Register AAD App'
+
+  - powershell: | 
+      Set-AzureADApplicationReplyUrls `
+      -AzureTenantIdSecondary '$(vh_hearings_tenata_id)' `
+      -AzureAdAppIdSecondary '$(vh_hearings_vsts_automation_AppId)' `
+      -AzureAdAppCertificateThumbprintSecondary '$(vh_hearings_vsts_automation_CertThumbprit)' `
+      -AADAppName "'${{ parameters.serviceName }}'-$(environmentName)" `
+      -AADAppReplyUrls "$(AADAppReplyUrls)"
+    displayName: 'Set AAD App Replay URLs'
+
+  - task: AzurePowerShell@3
+    displayName: 'Set DNS records for web app'
+    inputs:
+      azureSubscription: 'DCD-CFT-VH-Pilot'
+      azurePowerShellVersion: LatestVersion
+      ScriptType: InlineScript
+      Inline: |
+        Set-AzureRmDnsRecord -WebSiteName "'${{ parameters.serviceName }}'-$(environmentName)" `
+        -AzureAppServiceWebSiteDomainName "$(AzureAppServiceWebSiteDomainName)" `
+        -AzureResourceGroupName "$(AzureResourceGroupName)" `
+        -AzureDNSZoneName "$(AzureDNSZoneName)"
+
+  - task: AzureResourceGroupDeployment@2
+    displayName: 'Provision Web App'
+    inputs:
+      azureSubscription: 'Reform-CFT-VH-Dev'
+      action: 'Create Or Update Resource Group'
+      resourceGroupName: '$(resourceGroupName)'
+      location: 'UK West'
+      csmFile: 'infrastructure/azuredeploy.json'
+      csmParametersFile: 'infrastructure/azuredeploy.parameters.json'
+      overrideParameters: -appServicePlanName $(AppServicePlanName) -AzureWebsite $(WebSiteName) -customHostname $(CustomHostname) -certificateThumbprint $(WildcardCertificateThumbprint)
+      deploymentMode: Incremental

--- a/jobs/aadAppRegistration.yml
+++ b/jobs/aadAppRegistration.yml
@@ -8,7 +8,7 @@ parameters:
   CustomHostname: $(WebSiteName)$(AzureAppServiceWebSiteCustomDomainName) # custom hostname used by the website
   aadAppReplyUrls: '' #CSV list of replay urls
 
-#${{ parameters.AppServicePlanName }}
+#${{ parameters.CustomHostname }}
 
 
 jobs:
@@ -79,5 +79,5 @@ jobs:
       location: 'UK West'
       csmFile: 'infrastructure/azuredeploy.json'
       csmParametersFile: 'infrastructure/azuredeploy.parameters.json'
-      overrideParameters: -appServicePlanName ${{ parameters.AppServicePlanName }} -AzureWebsite $(WebSiteName) -customHostname $(CustomHostname) -certificateThumbprint $(WildcardCertificateThumbprint)
+      overrideParameters: -appServicePlanName ${{ parameters.AppServicePlanName }} -AzureWebsite $(WebSiteName) -customHostname ${{ parameters.CustomHostname }} -certificateThumbprint $(WildcardCertificateThumbprint)
       deploymentMode: Incremental


### PR DESCRIPTION
This is a new template that can be used to perfomr AAD app registration and Website provisioning in a repeatable way.

Thsi tamplae will:
- regiter AAD app if it doesn't exist
- push the AAD app registration details to a key vault
- set replay URL's
- provision a website 