### PR TITLE
Changed .net core version form 2.1.401 to 2.2.104

### DIFF
--- a/templates/common/common.yml
+++ b/templates/common/common.yml
@@ -1,6 +1,6 @@
 parameters:
   nugetVersion: 4.7.1  # Min version must be 4.7.1
-  dotNetCoreVersion: 2.1.401
+  dotNetCoreVersion: 2.2.104
 
 steps:
   - task: GitVersion@4


### PR DESCRIPTION
This changed will make sure .net Core SDK version 2.2.104 is installed on build agent.