### PR TITLE
Fixing nuget restore

### DIFF
--- a/jobs/angularDotNetCore.yml
+++ b/jobs/angularDotNetCore.yml
@@ -21,6 +21,8 @@ jobs:
   steps:
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
     clean: ${{ parameters.cleanCheckout }}  # whether to fetch clean each time
+
+# Runs common steps - gitVersion, Nuget  
   - template: ../templates/common/common.yml
 
 # Performs npm steps - install, build, test, test publishing
@@ -37,6 +39,7 @@ jobs:
   - template: ../templates/vsBuild/vsBuild.yml
     parameters:
       buildConfiguration: '${{ parameters.buildConfiguration }}'
+      vstsFeedId: '${{ parameters.vstsFeedId }}'
 
 # Get secrets from Key Vault
   - template: ../templates/getSecrets/getSecrets.yml

--- a/templates/common/common.yml
+++ b/templates/common/common.yml
@@ -1,6 +1,6 @@
 parameters:
   nugetVersion: 4.9.3  # Min version must be 4.7.1
-  dotNetCoreVersion: 2.2.103
+  dotNetCoreVersion: 2.2.104
 
 steps:
   - task: GitVersion@4

--- a/templates/common/common.yml
+++ b/templates/common/common.yml
@@ -7,6 +7,11 @@ steps:
     displayName: GitVersion
     inputs:
       preferBundledVersion: false
+
+  - task: NuGetToolInstaller@0
+    displayName: 'Use NuGet ${{ parameters.nugetVersion }}'
+    inputs:
+      versionSpec: ${{ parameters.nugetVersion }}
   
   - task: DotNetCoreInstaller@0
     displayName: 'Use .NET Core sdk ${{ parameters.dotNetCoreVersion }}'

--- a/templates/common/common.yml
+++ b/templates/common/common.yml
@@ -1,5 +1,5 @@
 parameters:
-  nugetVersion: 4.7.1  # Min version must be 4.7.1
+  nugetVersion: 4.8.1  # Min version must be 4.7.1
   dotNetCoreVersion: 2.2.103
 
 steps:

--- a/templates/common/common.yml
+++ b/templates/common/common.yml
@@ -1,5 +1,5 @@
 parameters:
-  nugetVersion: 4.9.3  # Min version must be 4.7.1
+  nugetVersion: 4.7.1  # Min version must be 4.7.1
   dotNetCoreVersion: 2.2.103
 
 steps:

--- a/templates/common/common.yml
+++ b/templates/common/common.yml
@@ -1,5 +1,5 @@
 parameters:
-  nugetVersion: 4.8.1  # Min version must be 4.7.1
+  nugetVersion: 4.9.3  # Min version must be 4.7.1
   dotNetCoreVersion: 2.2.103
 
 steps:

--- a/templates/vsBuild/vsBuild.yml
+++ b/templates/vsBuild/vsBuild.yml
@@ -7,6 +7,7 @@ steps:
     displayName: 'NuGet restore'
     inputs:
       restoreSolution: '*/*.sln'
+      vstsFeed: '${{ parameters.vstsFeedId }}'
 
 
 # Builds VS Solution

--- a/templates/vsBuild/vsBuild.yml
+++ b/templates/vsBuild/vsBuild.yml
@@ -8,7 +8,7 @@ steps:
     inputs:
       restoreSolution: '*/*.sln'
       vstsFeed: '${{ parameters.vstsFeedId }}'
-
+      includeNuGetOrg: false
 
 # Builds VS Solution
   - task: VSBuild@1

--- a/templates/vsBuild/vsBuild.yml
+++ b/templates/vsBuild/vsBuild.yml
@@ -1,7 +1,6 @@
 parameters:
   buildPlatform: 'Any CPU'
   buildConfiguration: ''
-  vstsFeedId: '0bb8fdf9-08cc-423c-8a96-81a1e4d65711'
 
 steps:
   - task: NuGetCommand@2

--- a/templates/vsBuild/vsBuild.yml
+++ b/templates/vsBuild/vsBuild.yml
@@ -1,6 +1,7 @@
 parameters:
   buildPlatform: 'Any CPU'
   buildConfiguration: ''
+  vstsFeedId: '0bb8fdf9-08cc-423c-8a96-81a1e4d65711'
 
 steps:
   - task: NuGetCommand@2

--- a/templates/vsBuild/vsBuild.yml
+++ b/templates/vsBuild/vsBuild.yml
@@ -7,7 +7,7 @@ steps:
     displayName: 'NuGet restore'
     inputs:
       restoreSolution: '*/*.sln'
-      includeNuGetOrg: false
+
 
 # Builds VS Solution
   - task: VSBuild@1

--- a/templates/vsBuild/vsBuild.yml
+++ b/templates/vsBuild/vsBuild.yml
@@ -3,11 +3,12 @@ parameters:
   buildConfiguration: ''
 
 steps:
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet restore'
+  - task: NuGetCommand@2
+    displayName: 'NuGet restore'
     inputs:
-      command: restore
-      projects: '**/*.sln'
+      restoreSolution: '*/*.sln'
+      vstsFeed: '${{ parameters.vstsFeedId }}'
+      includeNuGetOrg: false
 
 # Builds VS Solution
   - task: VSBuild@1

--- a/templates/vsBuild/vsBuild.yml
+++ b/templates/vsBuild/vsBuild.yml
@@ -7,8 +7,6 @@ steps:
     displayName: 'NuGet restore'
     inputs:
       restoreSolution: '*/*.sln'
-      vstsFeed: '${{ parameters.vstsFeedId }}'
-      includeNuGetOrg: false
 
 # Builds VS Solution
   - task: VSBuild@1

--- a/templates/vsBuild/vsBuild.yml
+++ b/templates/vsBuild/vsBuild.yml
@@ -7,6 +7,7 @@ steps:
     displayName: 'NuGet restore'
     inputs:
       restoreSolution: '*/*.sln'
+      includeNuGetOrg: false
 
 # Builds VS Solution
   - task: VSBuild@1


### PR DESCRIPTION
Fixed missing nuget feed ID that was casuing the builds to fail after upgrade to .Net Core 2.2 and NuGet 4.9.3