### PR TITLE
add mergeWith property for coverlet

### DIFF
--- a/templates/tests/runAllTests.yml
+++ b/templates/tests/runAllTests.yml
@@ -31,7 +31,7 @@ steps:
       projects: |
         **/*[Tt]ests/*.csproj
         !**/*Acceptance[Tt]ests/*.csproj
-      arguments: '--configuration ${{ parameters.buildConfiguration}} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat="\"opencover,cobertura,json,lcov\"" /p:Exclude="\"${{ parameters.coverletCoverageExclusions }}\"" /p:CoverletOutput=$(Common.TestResultsDirectory)\Coverage\'
+      arguments: '--configuration ${{ parameters.buildConfiguration}} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat="\"opencover,cobertura,json,lcov\"" /p:Exclude="\"${{ parameters.coverletCoverageExclusions }}\"" /p:CoverletOutput=$(Common.TestResultsDirectory)\Coverage\ /p:MergeWith=$(Common.TestResultsDirectory)\Coverage\coverage.json'
   
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish code coverage'


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Will merge results for test coverage results. If results file does not exist before merging, coverlet will create one.

**Does this PR introduce a breaking change?** (check one with "x")
Will require the affected repositories to update their versions of Coverlet. Team is aware
```
[x] Yes
[ ] No
```
