### PR TITLE
fixed the try/catch block so it actually works

### DIFF
--- a/jobs/secretGathering.yml
+++ b/jobs/secretGathering.yml
@@ -48,17 +48,16 @@ jobs:
           while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
           az keyvault network-rule add --name $env:keyVaultName --ip-address "$IP/32"
 
-          $ready = $false; $retry = 0
-          while($ready -eq $false -and $retry -lt 10) {
-            sleep (15 * $retry++)
-
-            try {
+          $ready = 1; $retry = 0
+          while($ready -ne 0 -and $retry -lt 10) {
+            sleep (15 * $retry++)  
+            try{          
               write-host "checking keyvault access"
               az keyvault secret list --vault-name $env:keyVaultName | out-null
-              $ready = $true
+              $ready = $LASTEXITCODE    
             } catch {
-              $ready = $false
-            }
+              $ready = 1
+            }        
           }
       env:
         keyVaultName: ${{ parameters.keyVault }}


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

orignal script was not executing as expected. When access is not allowed the az cli no longer returns an exception code so the catch block of the orignal script would never trigger. This will hopefully work around that.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
