### PR TITLE
Vih 8117 firewall removal error handling

### DIFF
--- a/jobs/secretGathering.yml
+++ b/jobs/secretGathering.yml
@@ -89,6 +89,7 @@ jobs:
             } catch {
               $ready = 1
             } 
+          }
       env:
         keyVaultName: ${{ parameters.keyVault }}
 

--- a/jobs/secretGathering.yml
+++ b/jobs/secretGathering.yml
@@ -84,7 +84,7 @@ jobs:
           while($ready -ne 0 -and $retry -lt 10) {
             sleep (10 * $retry++)  
             try{          
-              az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32" --debug
+              az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32"
               $ready = $LASTEXITCODE    
             } catch {
               $ready = 1

--- a/jobs/secretGathering.yml
+++ b/jobs/secretGathering.yml
@@ -79,10 +79,16 @@ jobs:
         scriptLocation: inlineScript
         inlineScript: |
           while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
-          write-host "Our IP address is: $ip"
-          az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32" --debug
+          write-host "Our IP address is: $ip"          
 
-
+          while($ready -ne 0 -and $retry -lt 10) {
+            sleep (10 * $retry++)  
+            try{          
+              az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32" --debug
+              $ready = $LASTEXITCODE    
+            } catch {
+              $ready = 1
+            } 
       env:
         keyVaultName: ${{ parameters.keyVault }}
 

--- a/jobs/secretGathering.yml
+++ b/jobs/secretGathering.yml
@@ -79,7 +79,10 @@ jobs:
         scriptLocation: inlineScript
         inlineScript: |
           while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
-          az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32"
+          write-host "Our IP address is: $ip"
+          az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32" --debug
+
+
       env:
         keyVaultName: ${{ parameters.keyVault }}
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-8117

### Change description ###

Removing Firewall rules during the set-up stage sometimes errors out which causes the pipeline to fail. Not great for nightly runs. Adding a try/catch to this should solve the failures without leaving a mess of IP's in the KV's FW ruleset

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
