### PR TITLE
Vih 7946 skip dupe nuget packages

### DIFF
--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -295,26 +295,28 @@ stages:
               arguments: '--configuration release /p:Version="$(GitVersion.NuGetVersion)" /p:PackageOutputPath="$(Build.ArtifactStagingDirectory)" /p:VersionSuffix="-alpha"'
             workingDirectory: ${{ parameters.nugetProjectPath }}
 
-        - ${{ if contains(parameters.lowerEnvs, parameters.environment) }}:
-          - task: NuGetAuthenticate@0
-
-          - task: NuGetCommand@2
-            inputs:
-              command: 'push'
-              packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-              publishVstsFeed: ${{ parameters.vstsFeedId }}
-              versioningScheme: byBuildNumber
-              allowPackageConflicts: true
-              nuGetFeedType: internal
-
-        - ${{ if contains(parameters.upperEnvs, parameters.environment) }}:
-          - task: DotNetCoreCLI@2
-            displayName: Push Package to VH NuGet Store
-            inputs:
-              command: push
-              searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-              publishVstsFeed: ${{ parameters.vstsFeedId }}
-              versioningScheme: byBuildNumber
+        
+        - task: NuGetAuthenticate@0
+          condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environemnt) }})
+          
+        - task: NuGetCommand@2
+          condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environemnt) }})
+          inputs:
+            command: 'push'
+            packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+            publishVstsFeed: ${{ parameters.vstsFeedId }}
+            versioningScheme: byBuildNumber
+            allowPackageConflicts: true
+            nuGetFeedType: internal
+      
+        - task: DotNetCoreCLI@2
+          condition: and(succeeded(), ${{ containsValue(parameters.upperEnvs, parameters.environemnt) }})
+          displayName: Push Package to VH NuGet Store
+          inputs:
+            command: push
+            searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+            publishVstsFeed: ${{ parameters.vstsFeedId }}
+            versioningScheme: byBuildNumber
 
 - ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
   - ${{ if eq(parameters.Test, true) }}:

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -305,10 +305,9 @@ stages:
             packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
             publishVstsFeed: ${{ parameters.vstsFeedId }}
             versioningScheme: byBuildNumber
-            condition: 
-              ${{ if contains(parameters.lowerEnvs, parameters.environment)  }})
+            ${{ if contains(parameters.lowerEnvs, parameters.environment)  }})
               allowPackageConflicts: true
-              ${{ if contains(parameters.upperEnvs, parameters.environment)  }})
+            ${{ if contains(parameters.upperEnvs, parameters.environment)  }})
               allowPackageConflicts: false
             nuGetFeedType: internal
       

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -299,7 +299,11 @@ stages:
           displayName: checking vars
           inputs: 
             targetType: 'inline'
-            script: echo 'Environment - ${{ parameters.environment }}.' 
+            script: | 
+            for e in ${{ parameters.environment[@] }}
+            do
+              echo 'Environment - $e \n' 
+            done
 
         - task: NuGetAuthenticate@0
           displayName: Connect to VH NuGet store

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -84,7 +84,7 @@ parameters:
   - name: lowerEnvs
     type: object
     values: []
-    default: ['sandbox','dev','demo','test1','aat', 'preview', 'test2']
+    default: ['sandbox', 'dev', 'demo', 'test1', 'aat', 'preview', 'test2']
 
   - name: upperEnvs
     type: object

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -297,10 +297,10 @@ stages:
 
         
         - task: NuGetAuthenticate@0
-          condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environemnt) }})
-          
+          condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environment) }})
+
         - task: NuGetCommand@2
-          condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environemnt) }})
+          condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environment) }})
           inputs:
             command: 'push'
             packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
@@ -310,7 +310,7 @@ stages:
             nuGetFeedType: internal
       
         - task: DotNetCoreCLI@2
-          condition: and(succeeded(), ${{ containsValue(parameters.upperEnvs, parameters.environemnt) }})
+          condition: and(succeeded(), ${{ containsValue(parameters.upperEnvs, parameters.environment) }})
           displayName: Push Package to VH NuGet Store
           inputs:
             command: push

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -292,14 +292,6 @@ stages:
             allowPackageConflicts: true
             nuGetFeedType: internal
 
-        #- task: DotNetCoreCLI@2
-        #  displayName: Push Package to VH NuGet Store
-        #  inputs:
-        #    command: push --skip-duplicate
-        #    searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-        #    publishVstsFeed: ${{ parameters.vstsFeedId }}
-        #    versioningScheme: byBuildNumber
-
 - ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
   - ${{ if eq(parameters.Test, true) }}:
     - template: ./dotnet-test.yml

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -315,8 +315,8 @@ stages:
             versioningScheme: byBuildNumber
             ${{ if containsValue(parameters.lowerEnvs, parameters.environment)  }}:
               allowPackageConflicts: true
-            ${{ if containsValue(parameters.upperEnvs, parameters.environment)  }}:
-              allowPackageConflicts: false
+            #${{ if containsValue(parameters.upperEnvs, parameters.environment)  }}:
+            #  allowPackageConflicts: false
             nuGetFeedType: internal
       
         #- task: DotNetCoreCLI@2

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -297,17 +297,19 @@ stages:
 
         
         - task: NuGetAuthenticate@0
-          condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environment) }})
 
         - task: NuGetCommand@2
-          condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environment) }})
+          #condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environment) }})
           inputs:
             command: 'push'
             packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
             publishVstsFeed: ${{ parameters.vstsFeedId }}
             versioningScheme: byBuildNumber
-            condition: and(succeeded(), ${{ containsValue(parameters.upperEnvs, parameters.environment) }})
+            condition: 
+              ${{ if contains(parameters.lowerEnvs, parameters.environment)  }})
               allowPackageConflicts: true
+              ${{ if contains(parameters.upperEnvs, parameters.environment)  }})
+              allowPackageConflicts: false
             nuGetFeedType: internal
       
         #- task: DotNetCoreCLI@2

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -306,17 +306,18 @@ stages:
             packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
             publishVstsFeed: ${{ parameters.vstsFeedId }}
             versioningScheme: byBuildNumber
-            allowPackageConflicts: true
+            condition: and(succeeded(), ${{ containsValue(parameters.upperEnvs, parameters.environment) }})
+              allowPackageConflicts: true
             nuGetFeedType: internal
       
-        - task: DotNetCoreCLI@2
-          condition: and(succeeded(), ${{ containsValue(parameters.upperEnvs, parameters.environment) }})
-          displayName: Push Package to VH NuGet Store
-          inputs:
-            command: push
-            searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-            publishVstsFeed: ${{ parameters.vstsFeedId }}
-            versioningScheme: byBuildNumber
+        #- task: DotNetCoreCLI@2
+        #  condition: and(succeeded(), ${{ containsValue(parameters.upperEnvs, parameters.environment) }})
+        #  displayName: Push Package to VH NuGet Store
+        #  inputs:
+        #    command: push
+        #    searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+        #    publishVstsFeed: ${{ parameters.vstsFeedId }}
+        #    versioningScheme: byBuildNumber
 
 - ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
   - ${{ if eq(parameters.Test, true) }}:

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -294,16 +294,13 @@ stages:
             ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/master')}}:
               arguments: '--configuration release /p:Version="$(GitVersion.NuGetVersion)" /p:PackageOutputPath="$(Build.ArtifactStagingDirectory)" /p:VersionSuffix="-alpha"'
             workingDirectory: ${{ parameters.nugetProjectPath }}
-
-        - task: bash@3
-          displayName: checking vars
-          inputs: 
-            targetType: 'inline'
-            script: | 
-            for e in ${{ parameters.environment[@] }}
-            do
-              echo 'Environment - $e \n' 
-            done
+        
+        - ${{ each e in parameters.environment }}:
+          - task: bash@3
+            displayName: checking vars
+            inputs: 
+              targetType: 'inline'
+              script: echo $e
 
         - task: NuGetAuthenticate@0
           displayName: Connect to VH NuGet store

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -305,9 +305,9 @@ stages:
             packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
             publishVstsFeed: ${{ parameters.vstsFeedId }}
             versioningScheme: byBuildNumber
-            ${{ if contains(parameters.lowerEnvs, parameters.environment)  }})
+            ${{ if contains(parameters.lowerEnvs, parameters.environment)  }}:
               allowPackageConflicts: true
-            ${{ if contains(parameters.upperEnvs, parameters.environment)  }})
+            ${{ if contains(parameters.upperEnvs, parameters.environment)  }}:
               allowPackageConflicts: false
             nuGetFeedType: internal
       

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -77,6 +77,20 @@ parameters:
     type: object
     default: {}
 
+  - name: environment
+    type: object
+    default: []
+
+  - name: lowerEnvs
+    type: object
+    values: []
+    default: ['sandbox','dev','demo','test1','aat', 'preview', 'test2']
+
+  - name: upperEnvs
+    type: object
+    values: []
+    default: ['prod', 'preprod']
+
 stages:
 - ${{ if or(parameters.PackageApp, parameters.PackageAcceptanceTests, parameters.ACTest, parameters.PackageNuget) }}:
   - stage: Package
@@ -280,17 +294,27 @@ stages:
             ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/master')}}:
               arguments: '--configuration release /p:Version="$(GitVersion.NuGetVersion)" /p:PackageOutputPath="$(Build.ArtifactStagingDirectory)" /p:VersionSuffix="-alpha"'
             workingDirectory: ${{ parameters.nugetProjectPath }}
-        
-        - task: NuGetAuthenticate@0
 
-        - task: NuGetCommand@2
-          inputs:
-            command: 'push'
-            packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-            publishVstsFeed: ${{ parameters.vstsFeedId }}
-            versioningScheme: byBuildNumber
-            allowPackageConflicts: true
-            nuGetFeedType: internal
+        - ${{ if contains(parameters.lowerEnvs, parameters.environment) }}:
+          - task: NuGetAuthenticate@0
+
+          - task: NuGetCommand@2
+            inputs:
+              command: 'push'
+              packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+              publishVstsFeed: ${{ parameters.vstsFeedId }}
+              versioningScheme: byBuildNumber
+              allowPackageConflicts: true
+              nuGetFeedType: internal
+
+        - ${{ if contains(parameters.upperEnvs, parameters.environment) }}:
+          - task: DotNetCoreCLI@2
+            displayName: Push Package to VH NuGet Store
+            inputs:
+              command: push
+              searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+              publishVstsFeed: ${{ parameters.vstsFeedId }}
+              versioningScheme: byBuildNumber
 
 - ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
   - ${{ if eq(parameters.Test, true) }}:

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -299,7 +299,7 @@ stages:
           displayName: checking vars
           inputs: 
             targetType: 'inline'
-            script: echo 'Environment - ${{ parameters.environment }}. Uppers - ${{ parameters.upperEnvs }}. Lowers - ${{ parameters.lowerEnvs }} "
+            script: echo 'Environment - ${{ parameters.environment }}.' 
 
         - task: NuGetAuthenticate@0
           displayName: Connect to VH NuGet store

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -295,10 +295,17 @@ stages:
               arguments: '--configuration release /p:Version="$(GitVersion.NuGetVersion)" /p:PackageOutputPath="$(Build.ArtifactStagingDirectory)" /p:VersionSuffix="-alpha"'
             workingDirectory: ${{ parameters.nugetProjectPath }}
 
-        
+        - task: bash@3
+          displayName: checking vars
+          inputs: 
+            targetType: 'inline'
+            script: echo 'Environment - ${{ parameters.environment }}. Uppers - ${{ parameters.upperEnvs }}. Lowers - ${{ parameters.lowerEnvs }} "
+
         - task: NuGetAuthenticate@0
+          displayName: Connect to VH NuGet store
 
         - task: NuGetCommand@2
+          displayName: Push Package to VH NuGet Store
           #condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environment) }})
           inputs:
             command: 'push'

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -295,19 +295,11 @@ stages:
               arguments: '--configuration release /p:Version="$(GitVersion.NuGetVersion)" /p:PackageOutputPath="$(Build.ArtifactStagingDirectory)" /p:VersionSuffix="-alpha"'
             workingDirectory: ${{ parameters.nugetProjectPath }}
         
-        - ${{ each e in parameters.environment }}:
-          - task: bash@3
-            displayName: checking vars
-            inputs: 
-              targetType: 'inline'
-              script: echo $e
-
         - task: NuGetAuthenticate@0
           displayName: Connect to VH NuGet store
 
         - task: NuGetCommand@2
           displayName: Push Package to VH NuGet Store
-          #condition: and(succeeded(), ${{ containsValue(parameters.lowerEnvs, parameters.environment) }})
           inputs:
             command: 'push'
             packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
@@ -315,19 +307,10 @@ stages:
             versioningScheme: byBuildNumber
             ${{ if containsValue(parameters.lowerEnvs, parameters.environment)  }}:
               allowPackageConflicts: true
-            #${{ if containsValue(parameters.upperEnvs, parameters.environment)  }}:
-            #  allowPackageConflicts: false
+            ${{ if containsValue(parameters.upperEnvs, parameters.environment)  }}:
+              allowPackageConflicts: false
             nuGetFeedType: internal
       
-        #- task: DotNetCoreCLI@2
-        #  condition: and(succeeded(), ${{ containsValue(parameters.upperEnvs, parameters.environment) }})
-        #  displayName: Push Package to VH NuGet Store
-        #  inputs:
-        #    command: push
-        #    searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-        #    publishVstsFeed: ${{ parameters.vstsFeedId }}
-        #    versioningScheme: byBuildNumber
-
 - ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
   - ${{ if eq(parameters.Test, true) }}:
     - template: ./dotnet-test.yml

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -305,9 +305,9 @@ stages:
             packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
             publishVstsFeed: ${{ parameters.vstsFeedId }}
             versioningScheme: byBuildNumber
-            ${{ if contains(parameters.lowerEnvs, parameters.environment)  }}:
+            ${{ if containsValue(parameters.lowerEnvs, parameters.environment)  }}:
               allowPackageConflicts: true
-            ${{ if contains(parameters.upperEnvs, parameters.environment)  }}:
+            ${{ if containsValue(parameters.upperEnvs, parameters.environment)  }}:
               allowPackageConflicts: false
             nuGetFeedType: internal
       

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -280,14 +280,25 @@ stages:
             ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/master')}}:
               arguments: '--configuration release /p:Version="$(GitVersion.NuGetVersion)" /p:PackageOutputPath="$(Build.ArtifactStagingDirectory)" /p:VersionSuffix="-alpha"'
             workingDirectory: ${{ parameters.nugetProjectPath }}
+        
+        - task: NuGetAuthenticate@0
 
-        - task: DotNetCoreCLI@2
-          displayName: Push Package to VH NuGet Store
+        - task: NuGetCommand@2
           inputs:
-            command: push
-            searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+            command: 'push'
+            packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
             publishVstsFeed: ${{ parameters.vstsFeedId }}
             versioningScheme: byBuildNumber
+            allowPackageConflicts: true
+            nuGetFeedType: internal
+
+        #- task: DotNetCoreCLI@2
+        #  displayName: Push Package to VH NuGet Store
+        #  inputs:
+        #    command: push --skip-duplicate
+        #    searchPatternPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+        #    publishVstsFeed: ${{ parameters.vstsFeedId }}
+        #    versioningScheme: byBuildNumber
 
 - ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
   - ${{ if eq(parameters.Test, true) }}:


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Duplicate packaged due to re-run builds causing issues with team delivery as seen here
https://hmctsreform.visualstudio.com/VirtualHearings/_build/results?buildId=36824&view=results
this will skip the push when there are duplicate packages 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
