### PR TITLE
Force dotnet version

### DIFF
--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -81,6 +81,10 @@ parameters:
     type: object
     default: {}
 
+  - name: netVersion
+    type: string
+    default: '5.1'
+
 stages:
 - ${{ if or(parameters.PackageApp, parameters.PackageAcceptanceTests, parameters.ACTest, parameters.PackageNuget) }}:
   - stage: Package
@@ -134,6 +138,13 @@ stages:
             packageManagers:
             - ${{ if parameters.packageManagers }}:
               - ${{ parameters.packageManagers }}
+        
+        - task: UseDotNet@2
+          displayName: 'Use .NET Core sdk'
+          inputs:
+            packageType: sdk
+            version: ${{ parameters.netVersion}}
+            installationPath: $(Agent.ToolsDirectory)/dotnet
 
         - task: DotNetCoreCLI@2
           displayName: dotnet Restore

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -83,7 +83,7 @@ parameters:
 
   - name: netVersion
     type: string
-    default: '5.1.x'
+    default: '5.x'
 
 stages:
 - ${{ if or(parameters.PackageApp, parameters.PackageAcceptanceTests, parameters.ACTest, parameters.PackageNuget) }}:

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -265,7 +265,7 @@ stages:
             ArtifactName: AcceptanceTests
 
     - ${{ if eq(parameters.PackageNuget, true) }}:
-      - job: Publish_Nuget
+      - job: t
         
         pool:
           vmImage: ${{ parameters.baseAgent }}

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -83,7 +83,7 @@ parameters:
 
   - name: netVersion
     type: string
-    default: '5.1'
+    default: '5.1.x'
 
 stages:
 - ${{ if or(parameters.PackageApp, parameters.PackageAcceptanceTests, parameters.ACTest, parameters.PackageNuget) }}:
@@ -140,7 +140,7 @@ stages:
               - ${{ parameters.packageManagers }}
         
         - task: UseDotNet@2
-          displayName: 'Use .NET Core sdk'
+          displayName: 'Install .NET Core sdk'
           inputs:
             packageType: sdk
             version: ${{ parameters.netVersion}}

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -265,7 +265,7 @@ stages:
             ArtifactName: AcceptanceTests
 
     - ${{ if eq(parameters.PackageNuget, true) }}:
-      - job: t
+      - job: Publish Nuget
         
         pool:
           vmImage: ${{ parameters.baseAgent }}

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -265,7 +265,7 @@ stages:
             ArtifactName: AcceptanceTests
 
     - ${{ if eq(parameters.PackageNuget, true) }}:
-      - job: Publish Nuget
+      - job: Publish_Nuget
         
         pool:
           vmImage: ${{ parameters.baseAgent }}

--- a/stages/dotnet-package.yml
+++ b/stages/dotnet-package.yml
@@ -216,6 +216,13 @@ stages:
               nugetProjectPath: ${{ parameters.coreProjectPath }}.AcceptanceTests
             packageManagers:
             - nuget
+        
+        - task: UseDotNet@2
+          displayName: 'Install .NET Core sdk'
+          inputs:
+            packageType: sdk
+            version: ${{ parameters.netVersion}}
+            installationPath: $(Agent.ToolsDirectory)/dotnet
 
         - task: DotNetCoreCLI@2
           displayName: dotnet Restore

--- a/stages/dotnet-test.yml
+++ b/stages/dotnet-test.yml
@@ -188,12 +188,12 @@ stages:
             Write-Host "##vso[task.setvariable variable=Release.EnvironmentName]$environment"
           displayName: Set Environment Alias ENVVARS
 
-        - task: UseDotNet@2
-          displayName: 'Install .NET Core sdk'
-          inputs:
-            packageType: sdk
-            version: ${{ parameters.netVersion}}
-            installationPath: $(Agent.ToolsDirectory)/dotnet
+        #- task: UseDotNet@2
+        #  displayName: 'Install .NET Core sdk'
+        #  inputs:
+        #    packageType: sdk
+        #    version: ${{ parameters.netVersion}}
+        #    installationPath: $(Agent.ToolsDirectory)/dotnet
 
         - task: NodeTool@0
           displayName: Install Node Version
@@ -269,11 +269,11 @@ stages:
             inputs:
               versionSpec:  ${{ parameters.nodeVersion }}
 
-          #- task: Npm@1
-          #  displayName: Install Node Modules
-          #  inputs:
-          #    workingDir: ${{ parameters.nodeProjectPath }}
-          #    verbose: false
+          - task: Npm@1
+            displayName: Install Node Modules
+            inputs:
+              workingDir: ${{ parameters.nodeProjectPath }}
+              verbose: false
 
           - task: Npm@1
             displayName: Run Lint

--- a/stages/dotnet-test.yml
+++ b/stages/dotnet-test.yml
@@ -269,11 +269,11 @@ stages:
             inputs:
               versionSpec:  ${{ parameters.nodeVersion }}
 
-          - task: Npm@1
-            displayName: Install Node Modules
-            inputs:
-              workingDir: ${{ parameters.nodeProjectPath }}
-              verbose: false
+          #- task: Npm@1
+          #  displayName: Install Node Modules
+          #  inputs:
+          #    workingDir: ${{ parameters.nodeProjectPath }}
+          #    verbose: false
 
           - task: Npm@1
             displayName: Run Lint

--- a/stages/dotnet-test.yml
+++ b/stages/dotnet-test.yml
@@ -114,6 +114,10 @@ parameters:
     type: number
     default: -1
 
+  - name: netVersion
+    type: string
+    default: '5.x'
+
 stages:
   - stage: Test
     dependsOn:
@@ -183,6 +187,13 @@ stages:
             Write-Host "##vso[task.setvariable variable=environment]$environment"
             Write-Host "##vso[task.setvariable variable=Release.EnvironmentName]$environment"
           displayName: Set Environment Alias ENVVARS
+
+        - task: UseDotNet@2
+          displayName: 'Install .NET Core sdk'
+          inputs:
+            packageType: sdk
+            version: ${{ parameters.netVersion}}
+            installationPath: $(Agent.ToolsDirectory)/dotnet
 
         - task: NodeTool@0
           displayName: Install Node Version

--- a/stages/dotnet-test.yml
+++ b/stages/dotnet-test.yml
@@ -116,7 +116,7 @@ parameters:
 
   - name: netVersion
     type: string
-    default: '5.x'
+    default: '3.1.x'
 
 stages:
   - stage: Test
@@ -187,6 +187,13 @@ stages:
             Write-Host "##vso[task.setvariable variable=environment]$environment"
             Write-Host "##vso[task.setvariable variable=Release.EnvironmentName]$environment"
           displayName: Set Environment Alias ENVVARS
+
+        - task: UseDotNet@2
+          displayName: 'Install .NET Core sdk'
+          inputs:
+            packageType: sdk
+            version: ${{ parameters.netVersion}}
+            installationPath: $(Agent.ToolsDirectory)/dotnet
 
         - task: NodeTool@0
           displayName: Install Node Version

--- a/stages/dotnet-test.yml
+++ b/stages/dotnet-test.yml
@@ -188,13 +188,6 @@ stages:
             Write-Host "##vso[task.setvariable variable=Release.EnvironmentName]$environment"
           displayName: Set Environment Alias ENVVARS
 
-        #- task: UseDotNet@2
-        #  displayName: 'Install .NET Core sdk'
-        #  inputs:
-        #    packageType: sdk
-        #    version: ${{ parameters.netVersion}}
-        #    installationPath: $(Agent.ToolsDirectory)/dotnet
-
         - task: NodeTool@0
           displayName: Install Node Version
           inputs:


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Allowing a .Net version to be pushed from the pipeline, defaults to 5.x for tor building and 3.1.x for testing

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
