### PR TITLE
monitor metrics

### DIFF
--- a/templates/tests/Azure/LoadBalancer/healthprobe.yml
+++ b/templates/tests/Azure/LoadBalancer/healthprobe.yml
@@ -22,6 +22,7 @@ steps:
           resourceType="Microsoft.Network/loadBalancers"
 
           #wait for 2 rounds of the metrics to run before checking the probe
+          az monitor metrics list --resource $lbName --resource-group $rgName --resource-type $resourceType --metric $metricName
           sleep 2m
           healthResults=$(az monitor metrics list --resource $lbName --resource-group $rgName --resource-type $resourceType --metric $metricName --query "(value[0].timeseries[0].data)[55:60].average" -o tsv)
           echo $healthResults


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8544


### Change description ###
Second load balancer request added due to vm starting and stopping. Stop/starting vm's was resulting in failed Load Balancer state due to initial health probe results not being fully healthy.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
