### PR TITLE
VIH-9191 Adding donet version as param

### DIFF
--- a/templates/dotnet/replace-app-settings.yml
+++ b/templates/dotnet/replace-app-settings.yml
@@ -39,7 +39,7 @@ steps:
           
           } else {
               Write-Host "$($parentName) is not an object"
-              if (Test-Path env:$envName){
+              if (Test-Path env:$parentName){
                   Write-Host "Found value for $parentName"
                   $_.Value = $($environmentVars | Where-Object { $_.Name -eq "$parentName" }).Value
               } else {

--- a/templates/dotnet/run-acceptance-tests.yml
+++ b/templates/dotnet/run-acceptance-tests.yml
@@ -12,6 +12,10 @@ parameters:
   - name: azureSubscription
     type: string
 
+  - name: netVersion
+    type: string
+    default: '6.x'
+
 steps:
   - checkout: self
 
@@ -20,6 +24,13 @@ steps:
     inputs:
       artifact: AcceptanceTests
       path: $(Pipeline.Workspace)/AcceptanceTests-$(Build.BuildId)
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core SDK'
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.netVersion }}
+      installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - powershell: |
       $runtimeSettings = '<?xml version="1.0" encoding="utf-8"?><RunSettings><TestRunParameters><Parameter name="TargetEnvironment" value="Production"/></TestRunParameters></RunSettings>'


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-9191

### Change description ###

Adds the ability to specify a dotnet version when running acceptance tests (defaults to `6.x`)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
