### PR TITLE
VIH-9999 Change JMESPath in LB test

### DIFF
--- a/templates/tests/Azure/LoadBalancer/healthprobe.yml
+++ b/templates/tests/Azure/LoadBalancer/healthprobe.yml
@@ -23,7 +23,7 @@ steps:
 
           #wait for 2 rounds of the metrics to run before checking the probe
           sleep 3m
-          healthResults=$(az monitor metrics list --resource $lbName --resource-group $rgName --resource-type $resourceType --metric $metricName --query "(value[0].timeseries[0].data)[55:60].average" -o tsv)
+          healthResults=$(az monitor metrics list --resource $lbName --resource-group $rgName --resource-type $resourceType --metric $metricName --query "(value[0].timeseries[0].data)[-5:].average" -o tsv)
           echo $healthResults
 
           healthSuccess=true


### PR DESCRIPTION
### Change description ###

Change the query used in the LB tests to take the last 5 metrics rather that the 55-60th metric. Seeing failures when some services are taking a while to start.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```