### PR TITLE
Vh sonar dotnet fix

### DIFF
--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -38,7 +38,7 @@ steps:
 
       echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
-      sed -i "s|\/app\/||g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+      sed -i "s|\/app\/|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
       cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
     displayName: Replace Coverage File Paths

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -29,20 +29,20 @@ steps:
       dockerComposeCommand: up
       arguments: --build --abort-on-container-exit
 
-  - bash: |
-      ls -lt
+  # - bash: |
+  #     ls -lt
 
-      sourcesDirectory="$(Build.SourcesDirectory)"
-      coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
-      content=$(cat $coverageReport)
+  #     sourcesDirectory="$(Build.SourcesDirectory)"
+  #     coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
+  #     content=$(cat $coverageReport)
 
-      echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+  #     echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
-      sed -i "s|\/app\/|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+  #     sed -i "s|\/app\/|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
-      cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
-    displayName: Replace Coverage File Paths
-    workingDirectory: ${{ parameters.appName }}/Coverage
+  #     cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+  #   displayName: Replace Coverage File Paths
+  #   workingDirectory: ${{ parameters.appName }}/Coverage
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -38,7 +38,7 @@ steps:
 
       echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
-      sed -i "s|\/app\/|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+      sed -i "s|\/app|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
       cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
     displayName: Replace Coverage File Paths

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -29,6 +29,14 @@ steps:
       dockerComposeCommand: up
       arguments: --build --abort-on-container-exit
 
+  - bash: |
+      echo $(Build.SourcesDirectory)
+      ls
+      sed -i "s|/app|$(Build.SourcesDirectory)|" coverage.opencover.xml > tmp; cat tmp > coverage.opencover.xml; rm tmp
+      cat coverage.opencover.xml
+    displayName: Replace Coverage File Paths
+    workingDirectory: ${{ parameters.appName }}/Coverage
+
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"
     inputs:

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -44,6 +44,10 @@ steps:
   #   displayName: Replace Coverage File Paths
   #   workingDirectory: ${{ parameters.appName }}/Coverage
 
+  - bash: |
+      sed -i '' "s|\/app\/||g" ./*_VH_Test_Report/src/*.html
+    displayName: Replace Coverage File Paths
+
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"
     inputs:

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -29,28 +29,20 @@ steps:
       dockerComposeCommand: up
       arguments: --build --abort-on-container-exit
 
-  - powershell: |
-      # replace every instance of /app with the full path to the source directory in the coverage file
-      $reportFile = $(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml
+  - bash: |
+      ls -lt
 
-      ((Get-Content -path $reportFile -Raw) -replace '/app','$(Build.SourcesDirectory') | Set-Content -Path $reportFile
-      Get-Content -Path $reportFile
+      sourcesDirectory="$(Build.SourcesDirectory)"
+      coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
+      content=$(cat $coverageReport)
+
+      echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+
+      sed -i "s|\/app|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+
+      cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
     displayName: Replace Coverage File Paths
-
-  # - bash: |
-  #     ls -lt
-
-  #     sourcesDirectory="$(Build.SourcesDirectory)"
-  #     coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
-  #     content=$(cat $coverageReport)
-
-  #     echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
-
-  #     sed -i "s|\/app|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
-
-  #     cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
-  #   displayName: Replace Coverage File Paths
-  #   workingDirectory: ${{ parameters.appName }}/Coverage
+    workingDirectory: ${{ parameters.appName }}/Coverage
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -31,13 +31,14 @@ steps:
 
   - bash: |
       echo $(Build.SourcesDirectory)
+      ls
       sourcesDirectory="$(Build.SourcesDirectory)"
       coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
       chmod -R 777 "$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage"
       sed -i "s|/app|$sourcesDirectory|" $coverageReport
       cat coverage.opencover.xml
     displayName: Replace Coverage File Paths
-    workingDirectory: $(System.DefaultWorkingDirectory)/${{ parameters.appName }}/Coverage
+    workingDirectory: ${{ parameters.appName }}/Coverage
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -56,7 +56,7 @@ steps:
     inputs:
       testResultsFormat: "VSTest" # Options: JUnit, NUnit, VSTest, xUnit, cTest
       testResultsFiles: "**/*TestResults.trx"
-      searchFolder: $(System.DefaultWorkingDirectory)/TestResults
+      searchFolder: $(System.DefaultWorkingDirectory)/${{ parameters.appName }}/TestResults
       failTaskOnFailedTests: true
 
   - ${{ if eq(parameters.publishNodeTests, true) }}:

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -56,7 +56,6 @@ steps:
     inputs:
       testResultsFormat: "VSTest" # Options: JUnit, NUnit, VSTest, xUnit, cTest
       testResultsFiles: "**/*TestResults.trx"
-      searchFolder: $(System.DefaultWorkingDirectory)/${{ parameters.appName }}/TestResults
       failTaskOnFailedTests: true
 
   - ${{ if eq(parameters.publishNodeTests, true) }}:

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -31,15 +31,15 @@ steps:
 
   - bash: |
       ls -lt 
-      
+
       sourcesDirectory="$(Build.SourcesDirectory)"
       coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
       content=$(cat $coverageReport)
-      
+
       echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
             
-      sed -i "s|\/app|$sourcesDirectory|" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
-      
+      sed -i "s|\/app|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+
       cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
     displayName: Replace Coverage File Paths
     workingDirectory: ${{ parameters.appName }}/Coverage

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -38,7 +38,7 @@ steps:
 
       echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
-      sed -i "s|\/app|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+      sed -i "s|\/app\/||g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
       cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
     displayName: Replace Coverage File Paths

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -44,9 +44,9 @@ steps:
   #   displayName: Replace Coverage File Paths
   #   workingDirectory: ${{ parameters.appName }}/Coverage
 
-  - bash: |
-      sed -i '' "s|\/app\/||g" ./*_VH_Test_Report/src/*.html
-    displayName: Replace Coverage File Paths
+  # - bash: |
+  #     sed -i '' "s|\/app\/||g" ./*_VH_Test_Report/src/*.html
+  #   displayName: Replace Coverage File Paths
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -42,7 +42,7 @@ steps:
 
       cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
     displayName: Replace Coverage File Paths
-    workingDirectory: ${{ parameters.appName }}/Coverage
+    workingDirectory: $(System.DefaultWorkingDirectory)
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -38,7 +38,7 @@ steps:
       
       echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
             
-      sed -i "s|/app|$sourcesDirectory|" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+      sed -i "s|\/app|$sourcesDirectory|" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
       
       cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
     displayName: Replace Coverage File Paths

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -33,7 +33,7 @@ steps:
       # replace every instance of /app with the full path to the source directory in the coverage file
       $reportFile = $(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml
 
-      ((Get-Content -path $$reportFile -Raw) -replace '/app','$(Build.SourcesDirectory') | Set-Content -Path $reportFile
+      ((Get-Content -path $reportFile -Raw) -replace '/app','$(Build.SourcesDirectory') | Set-Content -Path $reportFile
       Get-Content -Path $reportFile
     displayName: Replace Coverage File Paths
 

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -31,11 +31,12 @@ steps:
 
   - bash: |
       echo $(Build.SourcesDirectory)
-      ls
-      sed -i "s|/app|$(Build.SourcesDirectory)|" coverage.opencover.xml > tmp; cat tmp > coverage.opencover.xml; rm tmp
+      sourcesDirectory="$(Build.SourcesDirectory)"
+      coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
+      sed -i "s|/app|$sourcesDirectory|" $coverageReport
       cat coverage.opencover.xml
     displayName: Replace Coverage File Paths
-    workingDirectory: ${{ parameters.appName }}/Coverage
+    workingDirectory: $(System.DefaultWorkingDirectory)/${{ parameters.appName }}/Coverage
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -29,24 +29,20 @@ steps:
       dockerComposeCommand: up
       arguments: --build --abort-on-container-exit
 
-  # - bash: |
-  #     ls -lt
+  - bash: |
+      ls -lt
 
-  #     sourcesDirectory="$(Build.SourcesDirectory)"
-  #     coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
-  #     content=$(cat $coverageReport)
+      sourcesDirectory="$(Build.SourcesDirectory)"
+      coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
+      content=$(cat $coverageReport)
 
-  #     echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+      echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
-  #     sed -i "s|\/app\/|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+      sed -i "s|\/app\/|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
 
-  #     cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
-  #   displayName: Replace Coverage File Paths
-  #   workingDirectory: ${{ parameters.appName }}/Coverage
-
-  # - bash: |
-  #     sed -i '' "s|\/app\/||g" ./*_VH_Test_Report/src/*.html
-  #   displayName: Replace Coverage File Paths
+      cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+    displayName: Replace Coverage File Paths
+    workingDirectory: ${{ parameters.appName }}/Coverage
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -33,6 +33,7 @@ steps:
       echo $(Build.SourcesDirectory)
       sourcesDirectory="$(Build.SourcesDirectory)"
       coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
+      chmod -R 777 "$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage"
       sed -i "s|/app|$sourcesDirectory|" $coverageReport
       cat coverage.opencover.xml
     displayName: Replace Coverage File Paths

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -29,20 +29,28 @@ steps:
       dockerComposeCommand: up
       arguments: --build --abort-on-container-exit
 
-  - bash: |
-      ls -lt 
+  - powershell: |
+      # replace every instance of /app with the full path to the source directory in the coverage file
+      $reportFile = $(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml
 
-      sourcesDirectory="$(Build.SourcesDirectory)"
-      coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
-      content=$(cat $coverageReport)
-
-      echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
-            
-      sed -i "s|\/app|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
-
-      cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+      ((Get-Content -path $$reportFile -Raw) -replace '/app','$(Build.SourcesDirectory') | Set-Content -Path $reportFile
+      Get-Content -Path $reportFile
     displayName: Replace Coverage File Paths
-    workingDirectory: ${{ parameters.appName }}/Coverage
+
+  # - bash: |
+  #     ls -lt
+
+  #     sourcesDirectory="$(Build.SourcesDirectory)"
+  #     coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
+  #     content=$(cat $coverageReport)
+
+  #     echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+
+  #     sed -i "s|\/app|$sourcesDirectory|g" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+
+  #     cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+  #   displayName: Replace Coverage File Paths
+  #   workingDirectory: ${{ parameters.appName }}/Coverage
 
   - task: PublishCodeCoverageResults@1
     displayName: "Publish Code Coverage Report"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -33,7 +33,7 @@ steps:
       ls -lt
 
       sourcesDirectory="$(Build.SourcesDirectory)"
-      coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
+      coverageReport="$(System.DefaultWorkingDirectory)/Coverage/coverage.opencover.xml"
       content=$(cat $coverageReport)
 
       echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"

--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -30,13 +30,17 @@ steps:
       arguments: --build --abort-on-container-exit
 
   - bash: |
-      echo $(Build.SourcesDirectory)
-      ls
+      ls -lt 
+      
       sourcesDirectory="$(Build.SourcesDirectory)"
       coverageReport="$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage/coverage.opencover.xml"
-      chmod -R 777 "$(System.DefaultWorkingDirectory)/AdminWebsite/Coverage"
-      sed -i "s|/app|$sourcesDirectory|" $coverageReport
-      cat coverage.opencover.xml
+      content=$(cat $coverageReport)
+      
+      echo $content > "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+            
+      sed -i "s|/app|$sourcesDirectory|" "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
+      
+      cat "$(System.DefaultWorkingDirectory)/coverage.opencover.xml"
     displayName: Replace Coverage File Paths
     workingDirectory: ${{ parameters.appName }}/Coverage
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

VIH-9849

### Change description ###

Add a step to change the full path in the coverage file from the one produced by the container to the agent workspace

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```