### PR TITLE
always publish api test results

### DIFF
--- a/stages/dotnet-tests/unit-and-integration-tests-container.yml
+++ b/stages/dotnet-tests/unit-and-integration-tests-container.yml
@@ -48,6 +48,7 @@ steps:
 
   - task: PublishTestResults@2
     displayName: Publish API Test Results
+    condition: succeededOrFailed()
     inputs:
       testResultsFormat: "VSTest" # Options: JUnit, NUnit, VSTest, xUnit, cTest
       testResultsFiles: "**/*TestResults.trx"


### PR DESCRIPTION
### JIRA link (if applicable) ###

NA

### Change description ###

Always let the publish test results run so that a user can view the failures in the tests tab instead of searching through the logs

<img width="386" alt="image" src="https://github.com/hmcts/azure-devops-templates/assets/41630528/f632f041-e75b-4b4f-81d7-e077549d559d">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```