### PR TITLE
VIH-10935 fix missing intermediate cert

### DIFF
--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -87,7 +87,7 @@ steps:
   - task: AzureCLI@2
     name: acmecert
     displayName: 'Request LE Cert for ${{ parameters.domain }}'
-    # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+    condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
     inputs:
       azureSubscription: '${{ parameters.subscriptionName }}'
       scriptType: 'pscore'
@@ -153,30 +153,9 @@ steps:
         Write-Host "##vso[task.setvariable variable=pfxFullChain;isOutput=true]$($generatedCert.PfxFullChain)"
         Write-Host "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$pfxPassword"
 
-  # - bash: |
-  #     outputPfx="$(Pipeline.Workspace)/output.pfx"
-  #     outputPem="$(Pipeline.Workspace)/chainCert.pem"
-
-  #     echo "" > ${outputPem}
-  #     cat ${fullChainFile} ${privateKeyFile} > ${outputPem}
-  #     cat ${outputPem}
-  #     openssl pkcs12 -export -out ${outputPfx} -in ${outputPem} -passin pass:${password} -passout pass:${password}
-
-  #     echo "##vso[task.setvariable variable=pfxPath;isOutput=true]${outputPfx}"
-  #     echo "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$password"
-
-  #   displayName: "Repackage Cert"
-  #   # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
-  #   failOnStderr: true
-  #   name: "packaged"
-  #   env:
-  #     fullChainFile: $(acmecert.fullChainFile)
-  #     privateKeyFile: $(acmecert.privateKeyFile)
-  #     password: $(acmecert.pfxPass)
-
   - task: AzureCLI@2
     displayName: 'Import Certificate into ${{ parameters.keyVaultName }}'
-    # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+    condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
     inputs:
       azureSubscription: '${{ parameters.subscriptionName }}'
       scriptType: 'pscore'

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -154,7 +154,8 @@ steps:
         Write-Host "##vso[task.setvariable variable=privateKeyPath;isOutput=true]$($generatedCert.KeyFile)"
         Write-Host "##vso[task.setvariable variable=pfxPath;isOutput=true]$($generatedCert.PfxFullChain)"
         Write-Host "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$pfxPassword"
-        cat $($generatedCert.ChainFile)
+        echo "Contents of FullChainFile:"
+        cat $($generatedCert.FullChainFile)
 
   - bash: |
       outputPfx="$(Pipeline.Workspace)/output.pfx"

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -155,6 +155,7 @@ steps:
         Write-Host "##vso[task.setvariable variable=privateKeyPath;isOutput=true]$($generatedCert.KeyFile)"
         Write-Host "##vso[task.setvariable variable=pfxPath;isOutput=true]$($generatedCert.PfxFullChain)"
         Write-Host "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$pfxPassword"
+        cat $($generatedCert.ChainFile)
 
   - bash: |
       outputPfx="$(Pipeline.Workspace)/output.pfx"

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -12,80 +12,80 @@ parameters:
 
 steps:
 
-  - task: AzureCLI@2
-    displayName: Add KeyVault FW Exception
-    inputs:
-      azureSubscription: ${{ parameters.subscriptionName }}
-      scriptType: pscore
-      scriptLocation: inlineScript
-      inlineScript: |
-        while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
-        write-host "Our IP address is: $ip"
-        az keyvault network-rule add --name $env:keyVaultName --ip-address "$IP/32"
+  # - task: AzureCLI@2
+  #   displayName: Add KeyVault FW Exception
+  #   inputs:
+  #     azureSubscription: ${{ parameters.subscriptionName }}
+  #     scriptType: pscore
+  #     scriptLocation: inlineScript
+  #     inlineScript: |
+  #       while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
+  #       write-host "Our IP address is: $ip"
+  #       az keyvault network-rule add --name $env:keyVaultName --ip-address "$IP/32"
 
-        $ready = 1; $retry = 0
-        while($ready -ne 0 -and $retry -lt 10) {
-          sleep (15 * $retry++)  
-          try{          
-            write-host "checking keyvault access"
-            az keyvault secret list --vault-name $env:keyVaultName | out-null
-            $ready = $LASTEXITCODE    
-          } catch {
-            $ready = 1
-          }        
-        }
-    env:
-      keyVaultName: ${{ parameters.keyVaultName }}
+  #       $ready = 1; $retry = 0
+  #       while($ready -ne 0 -and $retry -lt 10) {
+  #         sleep (15 * $retry++)  
+  #         try{          
+  #           write-host "checking keyvault access"
+  #           az keyvault secret list --vault-name $env:keyVaultName | out-null
+  #           $ready = $LASTEXITCODE    
+  #         } catch {
+  #           $ready = 1
+  #         }        
+  #       }
+  #   env:
+  #     keyVaultName: ${{ parameters.keyVaultName }}
 
-  - template: purge.yaml
-    parameters:
-      subscriptionName: ${{ parameters.subscriptionName }}
-      keyVaultName: ${{ parameters.keyVaultName }}
-      certificateName: "${{ parameters.product }}-${{ parameters.environment }}-le-cert"
+  # - template: purge.yaml
+  #   parameters:
+  #     subscriptionName: ${{ parameters.subscriptionName }}
+  #     keyVaultName: ${{ parameters.keyVaultName }}
+  #     certificateName: "${{ parameters.product }}-${{ parameters.environment }}-le-cert"
 
-  - task: AzureCLI@2
-    displayName: 'Check if Cert expired in ${{ parameters.keyVaultName }}'
-    name: cert
-    inputs:
-      azureSubscription: '${{ parameters.subscriptionName }}'
-      scriptType: 'pscore'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
+  # - task: AzureCLI@2
+  #   displayName: 'Check if Cert expired in ${{ parameters.keyVaultName }}'
+  #   name: cert
+  #   inputs:
+  #     azureSubscription: '${{ parameters.subscriptionName }}'
+  #     scriptType: 'pscore'
+  #     scriptLocation: 'inlineScript'
+  #     inlineScript: |
 
-        $env="${{ parameters.environment }}"
-        $product="${{ parameters.product }}"
-        $keyVaultName="${{ parameters.keyVaultName }}"
-        $certName="$product-$env-le-cert"
+  #       $env="${{ parameters.environment }}"
+  #       $product="${{ parameters.product }}"
+  #       $keyVaultName="${{ parameters.keyVaultName }}"
+  #       $certName="$product-$env-le-cert"
 
-        $exportedCerts = az keyvault certificate list --vault-name $keyVaultName --query "[? name=='$certName']" -o json | ConvertFrom-Json
+  #       $exportedCerts = az keyvault certificate list --vault-name $keyVaultName --query "[? name=='$certName']" -o json | ConvertFrom-Json
 
-        $expired=$false
-        if ($null -ne $exportedCerts -and $exportedCerts.length -gt 0){
-          Write-Host "Certificate Found"
-          $exportedCert = $exportedCerts[0]
+  #       $expired=$false
+  #       if ($null -ne $exportedCerts -and $exportedCerts.length -gt 0){
+  #         Write-Host "Certificate Found"
+  #         $exportedCert = $exportedCerts[0]
 
-          Write-Host "Certificate Expires $($exportedCert.attributes.expires)"
-          $expiryDate=(get-date $exportedCert.attributes.expires).AddDays(-14)
-          Write-Host "Certificate Forced Expiry is $expiryDate"
+  #         Write-Host "Certificate Expires $($exportedCert.attributes.expires)"
+  #         $expiryDate=(get-date $exportedCert.attributes.expires).AddDays(-14)
+  #         Write-Host "Certificate Forced Expiry is $expiryDate"
           
-          if ($expiryDate -lt (get-date)){
-            Write-Host "Certificate has expired"
-            $expired=$true
-          } else {
-            Write-Host "Certificate has NOT expired"
-          }
+  #         if ($expiryDate -lt (get-date)){
+  #           Write-Host "Certificate has expired"
+  #           $expired=$true
+  #         } else {
+  #           Write-Host "Certificate has NOT expired"
+  #         }
 
-        } else {
-          Write-Host "Certificate NOT Found"
-          $expired=$true
-        }
+  #       } else {
+  #         Write-Host "Certificate NOT Found"
+  #         $expired=$true
+  #       }
 
-        Write-Host "##vso[task.setvariable variable=expired;isOutput=true]$expired"
+  #       Write-Host "##vso[task.setvariable variable=expired;isOutput=true]$expired"
 
   - task: AzureCLI@2
     name: acmecert
     displayName: 'Request LE Cert for ${{ parameters.domain }}'
-    condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+    # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
     inputs:
       azureSubscription: '${{ parameters.subscriptionName }}'
       scriptType: 'pscore'
@@ -131,7 +131,7 @@ steps:
 
         # Acquire access token for Azure (as we want to leverage the existing connection)
         Write-Host "Get Azure Details"
-        $azAccount = az account show -s "Reform-CFT-Mgmt" -o json | ConvertFrom-Json
+        $azAccount = az account show -s "UK Digital, Data & Cloud Solutions" -o json | ConvertFrom-Json
         Write-Host "Azure DNS Sub $($azAccount.name)"
         $token = (az account get-access-token --resource 'https://management.core.windows.net/' | ConvertFrom-Json).accessToken
 
@@ -196,25 +196,25 @@ steps:
 
   #       az keyvault certificate import --vault-name $keyVaultName -n $certName -f $pfxPath --password $password
 
-  - task: AzureCLI@2
-    displayName: Remove KeyVault FW Exception
-    condition: always()
-    inputs:
-      azureSubscription: ${{ parameters.subscriptionName }}
-      scriptType: pscore
-      scriptLocation: inlineScript
-      inlineScript: |
-        while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
-        write-host "Our IP address is: $ip"          
+  # - task: AzureCLI@2
+  #   displayName: Remove KeyVault FW Exception
+  #   condition: always()
+  #   inputs:
+  #     azureSubscription: ${{ parameters.subscriptionName }}
+  #     scriptType: pscore
+  #     scriptLocation: inlineScript
+  #     inlineScript: |
+  #       while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
+  #       write-host "Our IP address is: $ip"          
 
-        while($ready -ne 0 -and $retry -lt 10) {
-          sleep (10 * $retry++)  
-          try{          
-            az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32"
-            $ready = $LASTEXITCODE    
-          } catch {
-            $ready = 1
-          } 
-        }
-    env:
-      keyVaultName: ${{ parameters.keyVaultName }}
+  #       while($ready -ne 0 -and $retry -lt 10) {
+  #         sleep (10 * $retry++)  
+  #         try{          
+  #           az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32"
+  #           $ready = $LASTEXITCODE    
+  #         } catch {
+  #           $ready = 1
+  #         } 
+  #       }
+  #   env:
+  #     keyVaultName: ${{ parameters.keyVaultName }}

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -12,75 +12,75 @@ parameters:
 
 steps:
 
-  # - task: AzureCLI@2
-  #   displayName: Add KeyVault FW Exception
-  #   inputs:
-  #     azureSubscription: ${{ parameters.subscriptionName }}
-  #     scriptType: pscore
-  #     scriptLocation: inlineScript
-  #     inlineScript: |
-  #       while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
-  #       write-host "Our IP address is: $ip"
-  #       az keyvault network-rule add --name $env:keyVaultName --ip-address "$IP/32"
+  - task: AzureCLI@2
+    displayName: Add KeyVault FW Exception
+    inputs:
+      azureSubscription: ${{ parameters.subscriptionName }}
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
+        write-host "Our IP address is: $ip"
+        az keyvault network-rule add --name $env:keyVaultName --ip-address "$IP/32"
 
-  #       $ready = 1; $retry = 0
-  #       while($ready -ne 0 -and $retry -lt 10) {
-  #         sleep (15 * $retry++)  
-  #         try{          
-  #           write-host "checking keyvault access"
-  #           az keyvault secret list --vault-name $env:keyVaultName | out-null
-  #           $ready = $LASTEXITCODE    
-  #         } catch {
-  #           $ready = 1
-  #         }        
-  #       }
-  #   env:
-  #     keyVaultName: ${{ parameters.keyVaultName }}
+        $ready = 1; $retry = 0
+        while($ready -ne 0 -and $retry -lt 10) {
+          sleep (15 * $retry++)  
+          try{          
+            write-host "checking keyvault access"
+            az keyvault secret list --vault-name $env:keyVaultName | out-null
+            $ready = $LASTEXITCODE    
+          } catch {
+            $ready = 1
+          }        
+        }
+    env:
+      keyVaultName: ${{ parameters.keyVaultName }}
 
-  # - template: purge.yaml
-  #   parameters:
-  #     subscriptionName: ${{ parameters.subscriptionName }}
-  #     keyVaultName: ${{ parameters.keyVaultName }}
-  #     certificateName: "${{ parameters.product }}-${{ parameters.environment }}-le-cert"
+  - template: purge.yaml
+    parameters:
+      subscriptionName: ${{ parameters.subscriptionName }}
+      keyVaultName: ${{ parameters.keyVaultName }}
+      certificateName: "${{ parameters.product }}-${{ parameters.environment }}-le-cert"
 
-  # - task: AzureCLI@2
-  #   displayName: 'Check if Cert expired in ${{ parameters.keyVaultName }}'
-  #   name: cert
-  #   inputs:
-  #     azureSubscription: '${{ parameters.subscriptionName }}'
-  #     scriptType: 'pscore'
-  #     scriptLocation: 'inlineScript'
-  #     inlineScript: |
+  - task: AzureCLI@2
+    displayName: 'Check if Cert expired in ${{ parameters.keyVaultName }}'
+    name: cert
+    inputs:
+      azureSubscription: '${{ parameters.subscriptionName }}'
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
 
-  #       $env="${{ parameters.environment }}"
-  #       $product="${{ parameters.product }}"
-  #       $keyVaultName="${{ parameters.keyVaultName }}"
-  #       $certName="$product-$env-le-cert"
+        $env="${{ parameters.environment }}"
+        $product="${{ parameters.product }}"
+        $keyVaultName="${{ parameters.keyVaultName }}"
+        $certName="$product-$env-le-cert"
 
-  #       $exportedCerts = az keyvault certificate list --vault-name $keyVaultName --query "[? name=='$certName']" -o json | ConvertFrom-Json
+        $exportedCerts = az keyvault certificate list --vault-name $keyVaultName --query "[? name=='$certName']" -o json | ConvertFrom-Json
 
-  #       $expired=$false
-  #       if ($null -ne $exportedCerts -and $exportedCerts.length -gt 0){
-  #         Write-Host "Certificate Found"
-  #         $exportedCert = $exportedCerts[0]
+        $expired=$false
+        if ($null -ne $exportedCerts -and $exportedCerts.length -gt 0){
+          Write-Host "Certificate Found"
+          $exportedCert = $exportedCerts[0]
 
-  #         Write-Host "Certificate Expires $($exportedCert.attributes.expires)"
-  #         $expiryDate=(get-date $exportedCert.attributes.expires).AddDays(-14)
-  #         Write-Host "Certificate Forced Expiry is $expiryDate"
+          Write-Host "Certificate Expires $($exportedCert.attributes.expires)"
+          $expiryDate=(get-date $exportedCert.attributes.expires).AddDays(-14)
+          Write-Host "Certificate Forced Expiry is $expiryDate"
           
-  #         if ($expiryDate -lt (get-date)){
-  #           Write-Host "Certificate has expired"
-  #           $expired=$true
-  #         } else {
-  #           Write-Host "Certificate has NOT expired"
-  #         }
+          if ($expiryDate -lt (get-date)){
+            Write-Host "Certificate has expired"
+            $expired=$true
+          } else {
+            Write-Host "Certificate has NOT expired"
+          }
 
-  #       } else {
-  #         Write-Host "Certificate NOT Found"
-  #         $expired=$true
-  #       }
+        } else {
+          Write-Host "Certificate NOT Found"
+          $expired=$true
+        }
 
-  #       Write-Host "##vso[task.setvariable variable=expired;isOutput=true]$expired"
+        Write-Host "##vso[task.setvariable variable=expired;isOutput=true]$expired"
 
   - task: AzureCLI@2
     name: acmecert
@@ -181,43 +181,43 @@ steps:
       privateKeyFile: $(acmecert.privateKeyPath)
       password: $(acmecert.pfxPass)
 
-  # - task: AzureCLI@2
-  #   displayName: 'Import Certificate into ${{ parameters.keyVaultName }}'
-  #   condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
-  #   inputs:
-  #     azureSubscription: '${{ parameters.subscriptionName }}'
-  #     scriptType: 'pscore'
-  #     scriptLocation: 'inlineScript'
-  #     inlineScript: |
+  - task: AzureCLI@2
+    displayName: 'Import Certificate into ${{ parameters.keyVaultName }}'
+    # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+    inputs:
+      azureSubscription: '${{ parameters.subscriptionName }}'
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
 
-  #       $env="${{ parameters.environment }}"
-  #       $product="${{ parameters.product }}"
-  #       $keyVaultName="${{ parameters.keyVaultName }}"
-  #       $certName="$product-$env-le-cert"
-  #       $password="$(packaged.pfxPass)"
-  #       $pfxPath="$(packaged.pfxPath)"
+        $env="${{ parameters.environment }}"
+        $product="${{ parameters.product }}"
+        $keyVaultName="${{ parameters.keyVaultName }}"
+        $certName="$product-$env-le-cert"
+        $password="$(packaged.pfxPass)"
+        $pfxPath="$(packaged.pfxPath)"
 
-  #       az keyvault certificate import --vault-name $keyVaultName -n $certName -f $pfxPath --password $password
+        az keyvault certificate import --vault-name $keyVaultName -n $certName -f $pfxPath --password $password
 
-  # - task: AzureCLI@2
-  #   displayName: Remove KeyVault FW Exception
-  #   condition: always()
-  #   inputs:
-  #     azureSubscription: ${{ parameters.subscriptionName }}
-  #     scriptType: pscore
-  #     scriptLocation: inlineScript
-  #     inlineScript: |
-  #       while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
-  #       write-host "Our IP address is: $ip"          
+  - task: AzureCLI@2
+    displayName: Remove KeyVault FW Exception
+    condition: always()
+    inputs:
+      azureSubscription: ${{ parameters.subscriptionName }}
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
+        write-host "Our IP address is: $ip"          
 
-  #       while($ready -ne 0 -and $retry -lt 10) {
-  #         sleep (10 * $retry++)  
-  #         try{          
-  #           az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32"
-  #           $ready = $LASTEXITCODE    
-  #         } catch {
-  #           $ready = 1
-  #         } 
-  #       }
-  #   env:
-  #     keyVaultName: ${{ parameters.keyVaultName }}
+        while($ready -ne 0 -and $retry -lt 10) {
+          sleep (10 * $retry++)  
+          try{          
+            az keyvault network-rule remove --name $env:keyVaultName --ip-address "$IP/32"
+            $ready = $LASTEXITCODE    
+          } catch {
+            $ready = 1
+          } 
+        }
+    env:
+      keyVaultName: ${{ parameters.keyVaultName }}

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -101,11 +101,12 @@ steps:
         $domain="${{ parameters.domain }}"
         $acmeContact="$product@$env.com"
 
-        if ($env -eq "prod" -or $env -eq "stg" ) {
-          $leServer="LE_PROD"
-        }else {
-          $leServer="LE_STAGE"
-        }
+        # if ($env -eq "prod" -or $env -eq "stg" ) {
+        #   $leServer="LE_PROD"
+        # }else {
+        #   $leServer="LE_STAGE"
+        # }
+        $leServer="LE_STAGE"
         $pfxPassword="poshacme" # This is fixed by the module. Do not change
 
         # Set Posh-ACME working directory
@@ -148,34 +149,31 @@ steps:
         
         $generatedCert=$(Get-PACertificate)
         
-        Write-Host "##vso[task.setvariable variable=certPath;isOutput=true]$($generatedCert.FullChainFile)"
-        Write-Host "##vso[task.setvariable variable=privateKeyPath;isOutput=true]$($generatedCert.KeyFile)"
-        Write-Host "##vso[task.setvariable variable=pfxPath;isOutput=true]$($generatedCert.PfxFullChain)"
+        # Write-Host "##vso[task.setvariable variable=fullChainFile;isOutput=true]$($generatedCert.FullChainFile)"
+        # Write-Host "##vso[task.setvariable variable=privateKeyFile;isOutput=true]$($generatedCert.KeyFile)"
+        Write-Host "##vso[task.setvariable variable=pfxFullChain;isOutput=true]$($generatedCert.PfxFullChain)"
         Write-Host "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$pfxPassword"
-        echo "Contents of FullChainFile:"
-        cat $($generatedCert.FullChainFile)
 
-  - bash: |
-      outputPfx="$(Pipeline.Workspace)/output.pfx"
-      outputPem="$(Pipeline.Workspace)/chainCert.pem"
+  # - bash: |
+  #     outputPfx="$(Pipeline.Workspace)/output.pfx"
+  #     outputPem="$(Pipeline.Workspace)/chainCert.pem"
 
-      echo "" > ${outputPem}
-      ls -la
-      cat ${certFile} ${privateKeyFile} > ${outputPem}
-      cat ${outputPem}
-      openssl pkcs12 -export -out ${outputPfx} -in ${outputPem} -passin pass:${password} -passout pass:${password}
+  #     echo "" > ${outputPem}
+  #     cat ${fullChainFile} ${privateKeyFile} > ${outputPem}
+  #     cat ${outputPem}
+  #     openssl pkcs12 -export -out ${outputPfx} -in ${outputPem} -passin pass:${password} -passout pass:${password}
 
-      echo "##vso[task.setvariable variable=pfxPath;isOutput=true]${outputPfx}"
-      echo "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$password"
+  #     echo "##vso[task.setvariable variable=pfxPath;isOutput=true]${outputPfx}"
+  #     echo "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$password"
 
-    displayName: "Repackage Cert"
-    # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
-    failOnStderr: true
-    name: "packaged"
-    env:
-      certFile: $(acmecert.certPath)
-      privateKeyFile: $(acmecert.privateKeyPath)
-      password: $(acmecert.pfxPass)
+  #   displayName: "Repackage Cert"
+  #   # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+  #   failOnStderr: true
+  #   name: "packaged"
+  #   env:
+  #     fullChainFile: $(acmecert.fullChainFile)
+  #     privateKeyFile: $(acmecert.privateKeyFile)
+  #     password: $(acmecert.pfxPass)
 
   - task: AzureCLI@2
     displayName: 'Import Certificate into ${{ parameters.keyVaultName }}'
@@ -190,8 +188,8 @@ steps:
         $product="${{ parameters.product }}"
         $keyVaultName="${{ parameters.keyVaultName }}"
         $certName="$product-$env-le-cert"
-        $password="$(packaged.pfxPass)"
-        $pfxPath="$(packaged.pfxPath)"
+        $password="$(acmecert.pfxPass)"
+        $pfxPath="$(acmecert.pfxFullChain)"
 
         az keyvault certificate import --vault-name $keyVaultName -n $certName -f $pfxPath --password $password
 

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -143,16 +143,15 @@ steps:
         echo "Requesting new cert..."
         New-PACertificate $domain -Plugin Azure -PluginArgs $pArgs -Verbose
         
-        echo "Contents of new cert:"
         $generatedCert=$(Get-PACertificate)
         
         # chain.cer, chain0.cer and chain1.cer are outputted files, which chain1.cer contains only the intermediate
-        echo "ChainFile: "
-        $generatedCert.ChainFile
-        $intermediatePath=$($generatedCert.ChainFile -replace 'chain.cer','chain1.cer')
+        # echo "ChainFile: "
+        # $generatedCert.ChainFile
+        # $intermediatePath=$($generatedCert.ChainFile)
 
         Write-Host "##vso[task.setvariable variable=certPath;isOutput=true]$($generatedCert.CertFile)"
-        Write-Host "##vso[task.setvariable variable=intermediatePath;isOutput=true]$intermediatePath"
+        Write-Host "##vso[task.setvariable variable=intermediatePath;isOutput=true]$($generatedCert.ChainFile)"
         Write-Host "##vso[task.setvariable variable=privateKeyPath;isOutput=true]$($generatedCert.KeyFile)"
         Write-Host "##vso[task.setvariable variable=pfxPath;isOutput=true]$($generatedCert.PfxFullChain)"
         Write-Host "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$pfxPassword"

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -143,6 +143,7 @@ steps:
         New-PACertificate $domain -Plugin Azure -PluginArgs $pArgs -Verbose
 
         $generatedCert=$(Get-PACertificate)
+        Get-PACertificate | fl
         # chain.cer, chain0.cer and chain1.cer are outputted files, which chain1.cer contains only the intermediate
         $intermediatePath=$($generatedCert.ChainFile -replace 'chain.cer','chain1.cer')
 

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -131,7 +131,7 @@ steps:
 
         # Acquire access token for Azure (as we want to leverage the existing connection)
         Write-Host "Get Azure Details"
-        $azAccount = az account show -s "UK Digital, Data & Cloud Solutions" -o json | ConvertFrom-Json
+        $azAccount = az account show -s "Reform-CFT-Mgmt" -o json | ConvertFrom-Json
         Write-Host "Azure DNS Sub $($azAccount.name)"
         $token = (az account get-access-token --resource 'https://management.core.windows.net/' | ConvertFrom-Json).accessToken
 

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -101,12 +101,11 @@ steps:
         $domain="${{ parameters.domain }}"
         $acmeContact="$product@$env.com"
 
-        # if ($env -eq "prod" -or $env -eq "stg" ) {
-        #   $leServer="LE_PROD"
-        # }else {
-        #   $leServer="LE_STAGE"
-        # }
-        $leServer="LE_STAGE"
+        if ($env -eq "prod" -or $env -eq "stg" ) {
+          $leServer="LE_PROD"
+        }else {
+          $leServer="LE_STAGE"
+        }
         $pfxPassword="poshacme" # This is fixed by the module. Do not change
 
         # Set Posh-ACME working directory

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -98,12 +98,11 @@ steps:
         $domain="${{ parameters.domain }}"
         $acmeContact="$product@$env.com"
 
-        # if ($env -eq "prod" -or $env -eq "stg" ) {
-        #   $leServer="LE_PROD"
-        # }else {
-        #   $leServer="LE_STAGE"
-        # }
-        $leServer="LE_STAGE"
+        if ($env -eq "prod" -or $env -eq "stg" ) {
+          $leServer="LE_PROD"
+        }else {
+          $leServer="LE_STAGE"
+        }
         $pfxPassword="poshacme" # This is fixed by the module. Do not change
 
         # Set Posh-ACME working directory

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -91,7 +91,7 @@ steps:
       scriptType: 'pscore'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        $workingDirectory="$(Build.SourcesDirectory)"
+        $workingDirectory="$(Pipeline.Workspace)"
 
         $product="${{ parameters.product }}"
         $env="${{ parameters.environment }}"
@@ -140,11 +140,15 @@ steps:
           AZSubscriptionId = $azAccount.id
           AZAccessToken = $token
         }
+        echo "Requesting new cert..."
         New-PACertificate $domain -Plugin Azure -PluginArgs $pArgs -Verbose
-
+        
+        echo "Contents of new cert:"
         $generatedCert=$(Get-PACertificate)
-        Get-PACertificate | fl
+        
         # chain.cer, chain0.cer and chain1.cer are outputted files, which chain1.cer contains only the intermediate
+        echo "ChainFile: "
+        $generatedCert.ChainFile
         $intermediatePath=$($generatedCert.ChainFile -replace 'chain.cer','chain1.cer')
 
         Write-Host "##vso[task.setvariable variable=certPath;isOutput=true]$($generatedCert.CertFile)"
@@ -154,12 +158,12 @@ steps:
         Write-Host "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$pfxPassword"
 
   - bash: |
-      outputPfx="$(Build.SourcesDirectory)/output.pfx"
-      outputPem="$(Build.SourcesDirectory)/chainCert.pem"
+      outputPfx="$(Pipeline.Workspace)/output.pfx"
+      outputPem="$(Pipeline.Workspace)/chainCert.pem"
 
       echo "" > ${outputPem}
       ls -la
-      echo "certFile: ${certFile}""
+      echo "certFile: ${certFile}"
       echo "intermediateFile: ${intermediateFile}"
       echo "privateKeyFile: ${privateKeyFile}"
       cat ${certFile} ${intermediateFile} ${privateKeyFile} > ${outputPem}

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -157,6 +157,10 @@ steps:
       outputPem="$(Build.SourcesDirectory)/chainCert.pem"
 
       echo "" > ${outputPem}
+      ls -la
+      echo "certFile: ${certFile}""
+      echo "intermediateFile: ${intermediateFile}"
+      echo "privateKeyFile: ${privateKeyFile}"
       cat ${certFile} ${intermediateFile} ${privateKeyFile} > ${outputPem}
 
       openssl pkcs12 -export -out ${outputPfx} -in ${outputPem} -passin pass:${password} -passout pass:${password}
@@ -165,7 +169,7 @@ steps:
       echo "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$password"
 
     displayName: "Repackage Cert"
-    condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+    # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
     name: "packaged"
     env:
       certFile: $(acmecert.certPath)
@@ -173,23 +177,23 @@ steps:
       privateKeyFile: $(acmecert.privateKeyPath)
       password: $(acmecert.pfxPass)
 
-  - task: AzureCLI@2
-    displayName: 'Import Certificate into ${{ parameters.keyVaultName }}'
-    condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
-    inputs:
-      azureSubscription: '${{ parameters.subscriptionName }}'
-      scriptType: 'pscore'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
+  # - task: AzureCLI@2
+  #   displayName: 'Import Certificate into ${{ parameters.keyVaultName }}'
+  #   condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+  #   inputs:
+  #     azureSubscription: '${{ parameters.subscriptionName }}'
+  #     scriptType: 'pscore'
+  #     scriptLocation: 'inlineScript'
+  #     inlineScript: |
 
-        $env="${{ parameters.environment }}"
-        $product="${{ parameters.product }}"
-        $keyVaultName="${{ parameters.keyVaultName }}"
-        $certName="$product-$env-le-cert"
-        $password="$(packaged.pfxPass)"
-        $pfxPath="$(packaged.pfxPath)"
+  #       $env="${{ parameters.environment }}"
+  #       $product="${{ parameters.product }}"
+  #       $keyVaultName="${{ parameters.keyVaultName }}"
+  #       $certName="$product-$env-le-cert"
+  #       $password="$(packaged.pfxPass)"
+  #       $pfxPath="$(packaged.pfxPath)"
 
-        az keyvault certificate import --vault-name $keyVaultName -n $certName -f $pfxPath --password $password
+  #       az keyvault certificate import --vault-name $keyVaultName -n $certName -f $pfxPath --password $password
 
   - task: AzureCLI@2
     displayName: Remove KeyVault FW Exception

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -18,7 +18,7 @@ steps:
       azureSubscription: ${{ parameters.subscriptionName }}
       scriptType: pscore
       scriptLocation: inlineScript
-      failOnStandardError: true
+      failOnStandardError: false
       inlineScript: |
         while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
         write-host "Our IP address is: $ip"

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -150,8 +150,7 @@ steps:
         # $generatedCert.ChainFile
         # $intermediatePath=$($generatedCert.ChainFile)
 
-        Write-Host "##vso[task.setvariable variable=certPath;isOutput=true]$($generatedCert.CertFile)"
-        Write-Host "##vso[task.setvariable variable=intermediatePath;isOutput=true]$($generatedCert.ChainFile)"
+        Write-Host "##vso[task.setvariable variable=certPath;isOutput=true]$($generatedCert.FullChainFile)"
         Write-Host "##vso[task.setvariable variable=privateKeyPath;isOutput=true]$($generatedCert.KeyFile)"
         Write-Host "##vso[task.setvariable variable=pfxPath;isOutput=true]$($generatedCert.PfxFullChain)"
         Write-Host "##vso[task.setvariable variable=pfxPass;isOutput=true;issecret=true]$pfxPassword"
@@ -164,9 +163,8 @@ steps:
       echo "" > ${outputPem}
       ls -la
       echo "certFile: ${certFile}"
-      echo "intermediateFile: ${intermediateFile}"
       echo "privateKeyFile: ${privateKeyFile}"
-      cat ${certFile} ${intermediateFile} ${privateKeyFile} > ${outputPem}
+      cat ${certFile} ${privateKeyFile} > ${outputPem}
       cat ${outputPem}
       openssl pkcs12 -export -out ${outputPfx} -in ${outputPem} -passin pass:${password} -passout pass:${password}
 
@@ -178,7 +176,6 @@ steps:
     name: "packaged"
     env:
       certFile: $(acmecert.certPath)
-      intermediateFile: $(acmecert.intermediatePath)
       privateKeyFile: $(acmecert.privateKeyPath)
       password: $(acmecert.pfxPass)
 

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -14,11 +14,11 @@ steps:
 
   - task: AzureCLI@2
     displayName: Add KeyVault FW Exception
-    failOnStandardError: true
     inputs:
       azureSubscription: ${{ parameters.subscriptionName }}
       scriptType: pscore
       scriptLocation: inlineScript
+      failOnStandardError: true
       inlineScript: |
         while ( !$ip ) { $ip = (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content }
         write-host "Our IP address is: $ip"
@@ -46,12 +46,12 @@ steps:
 
   - task: AzureCLI@2
     displayName: 'Check if Cert expired in ${{ parameters.keyVaultName }}'
-    failOnStandardError: true
     name: cert
     inputs:
       azureSubscription: '${{ parameters.subscriptionName }}'
       scriptType: 'pscore'
       scriptLocation: 'inlineScript'
+      failOnStandardError: true
       inlineScript: |
 
         $env="${{ parameters.environment }}"
@@ -88,11 +88,11 @@ steps:
     name: acmecert
     displayName: 'Request LE Cert for ${{ parameters.domain }}'
     # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
-    failOnStandardError: true
     inputs:
       azureSubscription: '${{ parameters.subscriptionName }}'
       scriptType: 'pscore'
       scriptLocation: 'inlineScript'
+      failOnStandardError: true
       inlineScript: |
         $workingDirectory="$(Pipeline.Workspace)"
 

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -14,6 +14,7 @@ steps:
 
   - task: AzureCLI@2
     displayName: Add KeyVault FW Exception
+    failOnStandardError: true
     inputs:
       azureSubscription: ${{ parameters.subscriptionName }}
       scriptType: pscore
@@ -45,6 +46,7 @@ steps:
 
   - task: AzureCLI@2
     displayName: 'Check if Cert expired in ${{ parameters.keyVaultName }}'
+    failOnStandardError: true
     name: cert
     inputs:
       azureSubscription: '${{ parameters.subscriptionName }}'
@@ -86,6 +88,7 @@ steps:
     name: acmecert
     displayName: 'Request LE Cert for ${{ parameters.domain }}'
     # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+    failOnStandardError: true
     inputs:
       azureSubscription: '${{ parameters.subscriptionName }}'
       scriptType: 'pscore'
@@ -145,11 +148,6 @@ steps:
         
         $generatedCert=$(Get-PACertificate)
         
-        # chain.cer, chain0.cer and chain1.cer are outputted files, which chain1.cer contains only the intermediate
-        # echo "ChainFile: "
-        # $generatedCert.ChainFile
-        # $intermediatePath=$($generatedCert.ChainFile)
-
         Write-Host "##vso[task.setvariable variable=certPath;isOutput=true]$($generatedCert.FullChainFile)"
         Write-Host "##vso[task.setvariable variable=privateKeyPath;isOutput=true]$($generatedCert.KeyFile)"
         Write-Host "##vso[task.setvariable variable=pfxPath;isOutput=true]$($generatedCert.PfxFullChain)"
@@ -163,8 +161,6 @@ steps:
 
       echo "" > ${outputPem}
       ls -la
-      echo "certFile: ${certFile}"
-      echo "privateKeyFile: ${privateKeyFile}"
       cat ${certFile} ${privateKeyFile} > ${outputPem}
       cat ${outputPem}
       openssl pkcs12 -export -out ${outputPfx} -in ${outputPem} -passin pass:${password} -passout pass:${password}
@@ -174,6 +170,7 @@ steps:
 
     displayName: "Repackage Cert"
     # condition: and(succeeded(), eq(variables['cert.expired'], 'True'))
+    failOnStderr: true
     name: "packaged"
     env:
       certFile: $(acmecert.certPath)

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -167,7 +167,7 @@ steps:
       echo "intermediateFile: ${intermediateFile}"
       echo "privateKeyFile: ${privateKeyFile}"
       cat ${certFile} ${intermediateFile} ${privateKeyFile} > ${outputPem}
-
+      cat ${outputPem}
       openssl pkcs12 -export -out ${outputPfx} -in ${outputPem} -passin pass:${password} -passout pass:${password}
 
       echo "##vso[task.setvariable variable=pfxPath;isOutput=true]${outputPfx}"

--- a/templates/Azure/Certificates/Request.yaml
+++ b/templates/Azure/Certificates/Request.yaml
@@ -98,11 +98,12 @@ steps:
         $domain="${{ parameters.domain }}"
         $acmeContact="$product@$env.com"
 
-        if ($env -eq "prod" -or $env -eq "stg" ) {
-          $leServer="LE_PROD"
-        }else {
-          $leServer="LE_STAGE"
-        }
+        # if ($env -eq "prod" -or $env -eq "stg" ) {
+        #   $leServer="LE_PROD"
+        # }else {
+        #   $leServer="LE_STAGE"
+        # }
+        $leServer="LE_STAGE"
         $pfxPassword="poshacme" # This is fixed by the module. Do not change
 
         # Set Posh-ACME working directory


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-10935


### Change description ###
Uses the PfxFullChain created by LetEncrypt and the Posh-ACME module instead of individual chain certs, ensuring the cert now includes any intermediate certs.

FailOnStdErr now added as property to AzureCLI tasks to catch any potential future errors in the scripts.

Removes obsolete task to generate PFX from chain files.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```