### PR TITLE
Apply git version before docker build

### DIFF
--- a/templates/Containerisation/docker/docker-compose.yaml
+++ b/templates/Containerisation/docker/docker-compose.yaml
@@ -34,7 +34,7 @@ steps:
     inputs:
       useConfigFile: true
       configFilePath: '${{ parameters.gitVersionConfigPath }}'
-      additionalArguments: /updateassemblyinfo /ensureassemblyinfo
+      additionalArguments: /updateprojectfiles
 
   - script: |
       echo "##vso[task.setvariable variable=BuildVersion]$(GitVersion.FullSemVer)"

--- a/templates/Containerisation/docker/docker-compose.yaml
+++ b/templates/Containerisation/docker/docker-compose.yaml
@@ -33,7 +33,7 @@ steps:
     displayName: Determine Version for App
     inputs:
       useConfigFile: true
-      configFilePath: '${{ variables.git_version_config_path }}'
+      configFilePath: '${{ parameters.gitVersionConfigPath }}'
       updateAssemblyInfo: true
 
   - task: PowerShell@2

--- a/templates/Containerisation/docker/docker-compose.yaml
+++ b/templates/Containerisation/docker/docker-compose.yaml
@@ -35,6 +35,14 @@ steps:
       useConfigFile: true
       configFilePath: '${{ parameters.gitVersionConfigPath }}'
       additionalArguments: /updateassemblyinfo /ensureassemblyinfo
+  
+  - task: PowerShell@2
+    displayName: "Check Updated AssemblyInfo Files"
+    inputs:
+      targetType: 'inline'
+      script: |
+        git diff --name-only
+
 
   - task: PowerShell@2
     displayName: 'Run Docker Compose Build'

--- a/templates/Containerisation/docker/docker-compose.yaml
+++ b/templates/Containerisation/docker/docker-compose.yaml
@@ -52,7 +52,7 @@ steps:
         echo $dockerComposeFile
         $repositoryName = '${{ parameters.repositoryName }}'
         $projectName = ($repositoryName -split '/')[1]       
-        $buildCommand = "docker compose -f `"$dockerComposeFile`" -p `"$projectName`" build --build-arg BUILD_VERSION=$(BuildVersion) --build-arg ASSEMBLY_VERSION=$(AssemblyVersion) --build-arg FILE_VERSION=$(FileVersion)"
+        $buildCommand = "docker compose -f `"$dockerComposeFile`" -p `"$projectName`" build"
         Write-Host "Executing: $buildCommand"
         Invoke-Expression $buildCommand
         $upCommand = "docker compose -f `"$dockerComposeFile`" -p `"$projectName`" up -d"

--- a/templates/Containerisation/docker/docker-compose.yaml
+++ b/templates/Containerisation/docker/docker-compose.yaml
@@ -27,21 +27,14 @@ steps:
   - task: gitversion/setup@3
     displayName: Install GitVersion
     inputs:
-      versionSpec: '5.11.1'
+      versionSpec: '5.x'
 
   - task: gitversion/execute@3
     displayName: Determine Version for App
     inputs:
       useConfigFile: true
-      configFilePath: '${{ parameters.gitVersionConfigPath }}'
-      additionalArguments: /updateprojectfiles
-
-  - script: |
-      echo "##vso[task.setvariable variable=BuildVersion]$(GitVersion.FullSemVer)"
-      echo "##vso[task.setvariable variable=AssemblyVersion]$(GitVersion.AssemblySemVer)"
-      echo "##vso[task.setvariable variable=FileVersion]$(GitVersion.AssemblySemFileVer)"
-      echo "##vso[task.setvariable variable=InformationalVersion]$(GitVersion.InformationalVersion)"
-    displayName: "Set GitVersion Variables"
+      configFilePath: '${{ variables.git_version_config_path }}'
+      updateAssemblyInfo: true
 
   - task: PowerShell@2
     displayName: 'Run Docker Compose Build'

--- a/templates/Containerisation/docker/docker-compose.yaml
+++ b/templates/Containerisation/docker/docker-compose.yaml
@@ -21,6 +21,16 @@ steps:
         $acrId=az acr show -n '${{ parameters.acrName }}' --query "id" -o tsv
         echo "##vso[task.setvariable variable=acrId;isOutput=true]$acrId"
 
+  - task: gitversion/setup@3
+    displayName: Install GitVersion
+    inputs:
+      versionSpec: '5.11.1'
+
+  - task: gitversion/execute@3
+    displayName: Determine Version for AcceptanceTests
+    inputs:
+      additionalArguments: /updateassemblyinfo /ensureassemblyinfo
+
   - task: PowerShell@2
     displayName: 'Run Docker Compose Build'
     inputs:

--- a/templates/Containerisation/docker/docker-compose.yaml
+++ b/templates/Containerisation/docker/docker-compose.yaml
@@ -7,8 +7,11 @@ parameters:
     type: string
   - name: dockerComposeFile
     type: string
-    default:  "**/docker-compose.yml"
-    
+    default: "**/docker-compose.yml"
+  - name: gitVersionConfigPath
+    type: string
+    default: '$(Build.SourcesDirectory)/sds-git-version-config.yml'
+
 steps:
   - task: AzureCLI@2
     displayName: 'Get ID for ${{ parameters.acrName }}'
@@ -27,8 +30,10 @@ steps:
       versionSpec: '5.11.1'
 
   - task: gitversion/execute@3
-    displayName: Determine Version for AcceptanceTests
+    displayName: Determine Version for App
     inputs:
+      useConfigFile: true
+      configFilePath: '${{ parameters.gitVersionConfigPath }}'
       additionalArguments: /updateassemblyinfo /ensureassemblyinfo
 
   - task: PowerShell@2

--- a/templates/Containerisation/docker/docker-compose.yaml
+++ b/templates/Containerisation/docker/docker-compose.yaml
@@ -35,14 +35,13 @@ steps:
       useConfigFile: true
       configFilePath: '${{ parameters.gitVersionConfigPath }}'
       additionalArguments: /updateassemblyinfo /ensureassemblyinfo
-  
-  - task: PowerShell@2
-    displayName: "Check Updated AssemblyInfo Files"
-    inputs:
-      targetType: 'inline'
-      script: |
-        git diff --name-only
 
+  - script: |
+      echo "##vso[task.setvariable variable=BuildVersion]$(GitVersion.FullSemVer)"
+      echo "##vso[task.setvariable variable=AssemblyVersion]$(GitVersion.AssemblySemVer)"
+      echo "##vso[task.setvariable variable=FileVersion]$(GitVersion.AssemblySemFileVer)"
+      echo "##vso[task.setvariable variable=InformationalVersion]$(GitVersion.InformationalVersion)"
+    displayName: "Set GitVersion Variables"
 
   - task: PowerShell@2
     displayName: 'Run Docker Compose Build'
@@ -53,7 +52,7 @@ steps:
         echo $dockerComposeFile
         $repositoryName = '${{ parameters.repositoryName }}'
         $projectName = ($repositoryName -split '/')[1]       
-        $buildCommand = "docker compose -f `"$dockerComposeFile`" -p `"$projectName`" build"
+        $buildCommand = "docker compose -f `"$dockerComposeFile`" -p `"$projectName`" build --build-arg BUILD_VERSION=$(BuildVersion) --build-arg ASSEMBLY_VERSION=$(AssemblyVersion) --build-arg FILE_VERSION=$(FileVersion)"
         Write-Host "Executing: $buildCommand"
         Invoke-Expression $buildCommand
         $upCommand = "docker compose -f `"$dockerComposeFile`" -p `"$projectName`" up -d"


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Execute the GitVersion task as a part of `templates/Containerisation/docker/docker-compose.yaml`
This will update the assembly info of projects which in turn will allow VH apps to retrieve the version of the build within the application.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```